### PR TITLE
Fix angle normalization causing sudden heading jumps during path tracking

### DIFF
--- a/mpc_controller/controllers/mpc.py
+++ b/mpc_controller/controllers/mpc.py
@@ -214,8 +214,23 @@ class MPCController:
                 - Optimal control [v, omega]
                 - Info dict with predicted trajectory, solve time, etc.
         """
+        state_for_mpc = current_state.copy()
+
+        # Adjust reference trajectory theta to be continuous with current state
+        # This prevents issues when crossing the ±π boundary
+        ref_adjusted = reference_trajectory.copy()
+        current_theta = state_for_mpc[2]
+
+        for i in range(len(ref_adjusted)):
+            # Compute shortest angular difference from current theta to reference
+            ref_theta = ref_adjusted[i, 2]
+            diff = np.arctan2(np.sin(ref_theta - current_theta), np.cos(ref_theta - current_theta))
+            ref_adjusted[i, 2] = current_theta + diff
+            # Use this adjusted theta as the new "current" for continuity
+            current_theta = ref_adjusted[i, 2]
+
         # Build parameter vector
-        p = np.concatenate([current_state, reference_trajectory.flatten()])
+        p = np.concatenate([state_for_mpc, ref_adjusted.flatten()])
 
         # Initial guess (warm start)
         if self.prev_solution is not None:

--- a/mpc_controller/controllers/swerve_mpc.py
+++ b/mpc_controller/controllers/swerve_mpc.py
@@ -215,8 +215,21 @@ class SwerveMPCController:
                 - Optimal control [vx, vy, omega]
                 - Info dict with predicted trajectory, solve time, etc.
         """
+        state_for_mpc = current_state.copy()
+
+        # Adjust reference trajectory theta to be continuous with current state
+        # This prevents issues when crossing the ±π boundary
+        ref_adjusted = reference_trajectory.copy()
+        current_theta = state_for_mpc[2]
+
+        for i in range(len(ref_adjusted)):
+            ref_theta = ref_adjusted[i, 2]
+            diff = np.arctan2(np.sin(ref_theta - current_theta), np.cos(ref_theta - current_theta))
+            ref_adjusted[i, 2] = current_theta + diff
+            current_theta = ref_adjusted[i, 2]
+
         # Build parameter vector
-        p = np.concatenate([current_state, reference_trajectory.flatten()])
+        p = np.concatenate([state_for_mpc, ref_adjusted.flatten()])
 
         # Initial guess (warm start)
         if self.prev_solution is not None:

--- a/mpc_controller/models/differential_drive.py
+++ b/mpc_controller/models/differential_drive.py
@@ -84,8 +84,11 @@ class DifferentialDriveModel:
 
         state_next = self.state + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
 
-        # Normalize theta to [-pi, pi]
-        state_next[2] = ca.atan2(ca.sin(state_next[2]), ca.cos(state_next[2]))
+        # NOTE: theta is NOT normalized here to allow continuous angle tracking
+        # across the ±π boundary. The MPC cost function handles angle wrapping
+        # in the error computation using atan2(sin(err), cos(err)).
+        # This allows the optimizer to find smooth trajectories even when
+        # the reference trajectory crosses the ±π boundary.
 
         return ca.Function(
             "discrete_dynamics",

--- a/mpc_controller/models/non_coaxial_swerve.py
+++ b/mpc_controller/models/non_coaxial_swerve.py
@@ -148,8 +148,8 @@ class NonCoaxialSwerveDriveModel:
 
         state_next = self.state + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
 
-        # Normalize theta to [-pi, pi]
-        state_next[2] = ca.atan2(ca.sin(state_next[2]), ca.cos(state_next[2]))
+        # NOTE: theta is NOT normalized here to allow continuous angle tracking
+        # across the ±π boundary. The MPC cost function handles angle wrapping.
 
         # Clamp delta to steering limits
         max_delta = self.params.max_steering_angle

--- a/mpc_controller/models/swerve_drive.py
+++ b/mpc_controller/models/swerve_drive.py
@@ -106,8 +106,8 @@ class SwerveDriveModel:
 
         state_next = self.state + dt / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
 
-        # Normalize theta to [-pi, pi]
-        state_next[2] = ca.atan2(ca.sin(state_next[2]), ca.cos(state_next[2]))
+        # NOTE: theta is NOT normalized here to allow continuous angle tracking
+        # across the ±π boundary. The MPC cost function handles angle wrapping.
 
         return ca.Function(
             "discrete_dynamics",

--- a/mpc_controller/utils/__init__.py
+++ b/mpc_controller/utils/__init__.py
@@ -6,6 +6,9 @@ from mpc_controller.utils.trajectory import (
     generate_circle_trajectory,
     generate_figure_eight_trajectory,
     generate_sinusoidal_trajectory,
+    normalize_angle,
+    unwrap_angles,
+    angle_difference,
 )
 
 __all__ = [
@@ -14,4 +17,7 @@ __all__ = [
     "generate_circle_trajectory",
     "generate_figure_eight_trajectory",
     "generate_sinusoidal_trajectory",
+    "normalize_angle",
+    "unwrap_angles",
+    "angle_difference",
 ]

--- a/simulation/simulator.py
+++ b/simulation/simulator.py
@@ -222,15 +222,21 @@ def run_simulation(
     
     for step in range(num_steps):
         t = step * config.dt
-        
+
         # Get current measurement
         current_state = sim.get_measurement(add_noise)
-        
+
+        # Get current theta for angle continuity
+        # For non-coaxial swerve, state is [x, y, theta, delta], otherwise [x, y, theta]
+        current_theta = current_state[2]
+
         # Get reference trajectory for MPC horizon
+        # Pass current_theta to ensure angle continuity
         ref_traj = trajectory_interpolator.get_reference(
             t,
             controller.params.N,
             controller.params.dt,
+            current_theta=current_theta,
         )
         
         # Compute control


### PR DESCRIPTION
## Summary
경로 추종 중 ±π 경계를 넘을 때 heading이 급격하게 틀어지는 문제 수정

## Problem
- 로봇 heading이 ±π 근처에서 갑자기 큰 각도로 점프
- MPC optimizer가 경계 부근에서 불안정한 제어 출력

## Root Cause Analysis
```
┌─────────────────────────────────────────────────────────────┐
│  Before Fix (문제 상황)                                      │
├─────────────────────────────────────────────────────────────┤
│  Robot state:     θ = -179° (normalized)                    │
│  Reference:       θ = 181° (unwrapped from trajectory)      │
│  Error:           -179° - 181° = -360°                      │
│  MPC sees:        "Rotate 360° clockwise!"  ← WRONG         │
├─────────────────────────────────────────────────────────────┤
│  After Fix                                                   │
├─────────────────────────────────────────────────────────────┤
│  Robot state:     θ = -179°                                 │
│  Reference:       θ = -179° (adjusted to robot's range)     │
│  Error:           -179° - (-179°) = 0°                      │
│  MPC sees:        "Keep going!"  ← CORRECT                  │
└─────────────────────────────────────────────────────────────┘
```

## Changes
1. **Models**: Remove theta normalization from MPC dynamics
   - `mpc_controller/models/differential_drive.py`
   - `mpc_controller/models/swerve_drive.py`
   - `mpc_controller/models/non_coaxial_swerve.py`

2. **Controllers**: Add reference theta adjustment in compute_control
   - `mpc_controller/controllers/mpc.py`
   - `mpc_controller/controllers/swerve_mpc.py`
   - `mpc_controller/controllers/non_coaxial_swerve_mpc.py`

3. **Trajectory utilities**: Add angle handling functions
   - `normalize_angle()`: Normalize angle to [-π, π]
   - `unwrap_angles()`: Make angle array continuous
   - `angle_difference()`: Compute shortest angular difference

4. **Tests**: Add comprehensive angle boundary tests
   - `TestAngleNormalization`: Unit tests for utilities
   - `TestAngleBoundaryTracking`: MPC integration tests

## Test Results
Before fix:
```
Max omega change: 2.9569 rad/s  ← Sudden jumps!
```

After fix:
```
Max omega change: 0.0203 rad/s  ← Smooth control
```

Closes #8