### PR TITLE
fix: controller_server Aborting handle - local_costmap 파라미터 누락

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
+++ b/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
@@ -175,13 +175,15 @@ def launch_setup(context, *args, **kwargs):
     )
 
     # ========== 8. nav2 Nodes ==========
-    # controller_server: 컨트롤러별 전용 파라미터 파일 사용
+    # controller_server: 공통 파라미터(local_costmap 등) + 컨트롤러별 전용 파라미터
+    # nav2의 controller_server는 내부적으로 local_costmap 노드를 생성하므로
+    # 반드시 local_costmap 파라미터가 포함된 공통 파일도 함께 전달해야 함
     controller_server = Node(
         package='nav2_controller',
         executable='controller_server',
         name='controller_server',
         output='screen',
-        parameters=[controller_params_file],
+        parameters=[nav2_params_file, controller_params_file],
         remappings=[('cmd_vel', '/cmd_vel_nav')]
     )
 

--- a/ros2_ws/src/mpc_controller_ros2/src/mppi_controller_plugin.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/mppi_controller_plugin.cpp
@@ -354,6 +354,13 @@ std::vector<Eigen::Vector3d> MPPIControllerPlugin::extractObstaclesFromCostmap()
   }
 
   auto costmap = costmap_ros_->getCostmap();
+  if (!costmap) {
+    RCLCPP_WARN_THROTTLE(
+      node_->get_logger(), *node_->get_clock(), 2000,
+      "Costmap not yet available, skipping obstacle extraction"
+    );
+    return obstacles;
+  }
   unsigned int size_x = costmap->getSizeInCellsX();
   unsigned int size_y = costmap->getSizeInCellsY();
   double resolution = costmap->getResolution();


### PR DESCRIPTION
## Summary
- controller_server에 `local_costmap` 파라미터 누락으로 costmap 초기화 실패 → Aborting handle 반복 발생
- `extractObstaclesFromCostmap()`에 costmap nullptr 방어 코드 추가

## 원인
```
변경 전: parameters=[nav2_params.yaml]          ← local_costmap 포함
변경 후: parameters=[controller_params_file]    ← local_costmap 없음!

nav2 controller_server 내부 구조:
├─ FollowPath (MPPI plugin)  ← OK
└─ local_costmap             ← 파라미터 없음 → 초기화 실패 → Abort
```

## 수정
```python
# 공통 파라미터(local_costmap 등) + 컨트롤러 전용 파라미터 모두 전달
parameters=[nav2_params_file, controller_params_file]
```

## Test plan
- [ ] `ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py` → Aborting handle 없이 정상 동작
- [ ] `controller:=nav2` 전환 시에도 정상 동작
- [ ] costmap이 RViz에 정상 표시 확인

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)