### PR TITLE
fix: PreferForwardCost 추가로 후진 편향 해소

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_custom_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_custom_mppi.yaml
@@ -77,6 +77,9 @@ controller_server:
       obstacle_weight: 100.0
       safety_distance: 0.5
 
+      # Forward preference (후진 페널티)
+      prefer_forward_weight: 5.0
+
       # Visualization
       visualize_samples: true
       visualize_best: true

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/cost_functions.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/cost_functions.hpp
@@ -84,6 +84,23 @@ private:
   Eigen::Matrix2d R_rate_;
 };
 
+/**
+ * @brief 전진 선호 비용 (후진 시 페널티)
+ * cost = weight * Σ max(-v_t, 0)²
+ */
+class PreferForwardCost : public MPPICostFunction
+{
+public:
+  explicit PreferForwardCost(double weight);
+  Eigen::VectorXd compute(
+    const std::vector<Eigen::MatrixXd>& trajectories,
+    const std::vector<Eigen::MatrixXd>& controls,
+    const Eigen::MatrixXd& reference
+  ) const override;
+private:
+  double weight_;
+};
+
 class ObstacleCost : public MPPICostFunction
 {
 public:

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
@@ -38,6 +38,9 @@ struct MPPIParams
   double obstacle_weight{100.0};    // 장애물 회피 가중치
   double safety_distance{0.5};      // 안전 거리 (m)
 
+  // Forward preference
+  double prefer_forward_weight{5.0}; // 전진 선호 가중치 (후진 페널티)
+
   // Visualization
   bool visualize_samples{true};           // 샘플 궤적 표시
   bool visualize_best{true};              // 최적 궤적 표시

--- a/ros2_ws/src/mpc_controller_ros2/src/cost_functions.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/cost_functions.cpp
@@ -107,6 +107,35 @@ Eigen::VectorXd ControlRateCost::compute(
   return costs;
 }
 
+// PreferForwardCost
+PreferForwardCost::PreferForwardCost(double weight) : weight_(weight) {}
+
+Eigen::VectorXd PreferForwardCost::compute(
+  const std::vector<Eigen::MatrixXd>& trajectories,
+  const std::vector<Eigen::MatrixXd>& controls,
+  const Eigen::MatrixXd& reference
+) const
+{
+  (void)trajectories;
+  (void)reference;
+
+  int K = controls.size();
+  int N = controls[0].rows();
+  Eigen::VectorXd costs = Eigen::VectorXd::Zero(K);
+
+  for (int k = 0; k < K; ++k) {
+    for (int t = 0; t < N; ++t) {
+      double v = controls[k](t, 0);
+      if (v < 0.0) {
+        // 후진 시 이차 페널티: weight * v²
+        costs(k) += weight_ * v * v;
+      }
+    }
+  }
+
+  return costs;
+}
+
 // ObstacleCost
 ObstacleCost::ObstacleCost(double weight, double safety_distance)
 : weight_(weight), safety_distance_(safety_distance)


### PR DESCRIPTION
## Summary
- MPPI 샘플링에서 전진 선호 비용 함수가 없어 로봇이 후진만 하는 문제 수정
- `PreferForwardCost` 클래스 추가: `cost = weight * Σ max(-v_t, 0)²`
- 런타임 동적 파라미터 조정 지원

## 원인
```
노이즈 중심 = 0, σ_v = 0.5
→ 샘플의 ~50%가 v < 0 (후진)
→ ControlEffortCost: v² → 전진/후진 동일 비용
→ 전진 유도 비용 없음 → 후진 편향
```

## 수정
```
PreferForwardCost:
  v ≥ 0  → cost = 0        (전진: 페널티 없음)
  v < 0  → cost = w * v²   (후진: 이차 페널티)
```

## 변경 파일
| 파일 | 설명 |
|------|------|
| `cost_functions.hpp` | PreferForwardCost 클래스 선언 |
| `cost_functions.cpp` | PreferForwardCost::compute() 구현 |
| `mppi_params.hpp` | prefer_forward_weight 파라미터 |
| `mppi_controller_plugin.cpp` | 선언/로드/동적 콜백/비용함수 등록 |
| `nav2_params_custom_mppi.yaml` | prefer_forward_weight: 5.0 |

## Test plan
- [ ] 빌드 성공 확인
- [ ] 로봇이 전진 방향으로 주행하는지 확인
- [ ] `ros2 param set /controller_server FollowPath.prefer_forward_weight 10.0` 으로 런타임 조정 가능 확인

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)