### PR TITLE
feat: Log-MPPI C++ nav2 플러그인 구현

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
+++ b/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
@@ -52,6 +52,8 @@ ament_target_dependencies(mppi_utils
 # C++ library: MPPI controller plugin
 add_library(mppi_controller_plugin SHARED
   src/mppi_controller_plugin.cpp
+  src/log_mppi_controller_plugin.cpp
+  src/weight_computation.cpp
   src/batch_dynamics_wrapper.cpp
   src/cost_functions.cpp
   src/sampling.cpp
@@ -183,6 +185,11 @@ if(BUILD_TESTING)
   ament_add_gtest(test_mppi_algorithm test/unit/test_mppi_algorithm.cpp)
   if(TARGET test_mppi_algorithm)
     target_link_libraries(test_mppi_algorithm mppi_controller_plugin)
+  endif()
+
+  ament_add_gtest(test_weight_computation test/unit/test_weight_computation.cpp)
+  if(TARGET test_weight_computation)
+    target_link_libraries(test_weight_computation mppi_controller_plugin)
   endif()
 endif()
 

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_log_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_log_mppi.yaml
@@ -1,0 +1,91 @@
+# ============================================================
+# nav2 파라미터 - Log-MPPI (mpc_controller_ros2)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=log
+#
+# Log-MPPI는 Vanilla MPPI와 수학적으로 동일한 결과를 내지만,
+# log-space 가중치 계산을 사용하여 수치 안정성이 개선되며,
+# importance sampling 보정 등 후속 확장의 기반 역할을 합니다.
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    use_sim_time: true
+    controller_frequency: 10.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.001
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.5
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["goal_checker"]
+    controller_plugins: ["FollowPath"]
+
+    # Progress checker
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.3
+      movement_time_allowance: 30.0
+
+    # Goal checker
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.25
+      yaw_goal_tolerance: 0.25
+      stateful: true
+
+    # ---- Log-MPPI Controller (mpc_controller_ros2) ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::LogMPPIControllerPlugin"
+
+      # Prediction horizon
+      N: 30
+      dt: 0.1
+
+      # Sampling
+      K: 1024
+      lambda: 10.0
+
+      # Noise parameters
+      noise_sigma_v: 0.5
+      noise_sigma_omega: 0.5
+
+      # Control limits
+      v_max: 0.5
+      v_min: -0.2
+      omega_max: 1.0
+      omega_min: -1.0
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 1.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 2.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_omega: 0.1
+
+      # Control rate weights (R_rate)
+      R_rate_v: 1.0
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 100.0
+      safety_distance: 0.5
+
+      # Forward preference (후진 페널티)
+      prefer_forward_weight: 15.0
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/log_mppi_controller_plugin.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/log_mppi_controller_plugin.hpp
@@ -1,0 +1,28 @@
+#ifndef MPC_CONTROLLER_ROS2__LOG_MPPI_CONTROLLER_PLUGIN_HPP_
+#define MPC_CONTROLLER_ROS2__LOG_MPPI_CONTROLLER_PLUGIN_HPP_
+
+#include "mpc_controller_ros2/mppi_controller_plugin.hpp"
+#include "mpc_controller_ros2/weight_computation.hpp"
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief Log-MPPI nav2 Controller Plugin
+ *
+ * MPPIControllerPlugin을 상속하고 가중치 계산 전략만
+ * LogMPPIWeights로 교체한 플러그인.
+ *
+ * Vanilla MPPI와 수학적으로 동일하나, log-space 가중치 조작이 필요한
+ * 후속 확장(importance sampling 보정 등)의 기반 클래스로 활용.
+ */
+class LogMPPIControllerPlugin : public MPPIControllerPlugin
+{
+public:
+  LogMPPIControllerPlugin();
+  ~LogMPPIControllerPlugin() override = default;
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__LOG_MPPI_CONTROLLER_PLUGIN_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_controller_plugin.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_controller_plugin.hpp
@@ -17,6 +17,7 @@
 #include "mpc_controller_ros2/batch_dynamics_wrapper.hpp"
 #include "mpc_controller_ros2/cost_functions.hpp"
 #include "mpc_controller_ros2/sampling.hpp"
+#include "mpc_controller_ros2/weight_computation.hpp"
 
 namespace mpc_controller_ros2
 {
@@ -41,7 +42,7 @@ struct MPPIInfo
 class MPPIControllerPlugin : public nav2_core::Controller
 {
 public:
-  MPPIControllerPlugin() = default;
+  MPPIControllerPlugin();
   ~MPPIControllerPlugin() override = default;
 
   // nav2_core::Controller 인터페이스
@@ -64,6 +65,10 @@ public:
 
   void setPlan(const nav_msgs::msg::Path& path) override;
   void setSpeedLimit(const double& speed_limit, const bool& percentage) override;
+
+protected:
+  // Weight computation strategy (서브클래스에서 교체 가능)
+  std::unique_ptr<WeightComputation> weight_computation_;
 
 private:
   // MPPI 핵심 알고리즘

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/utils.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/utils.hpp
@@ -45,6 +45,15 @@ Eigen::VectorXd softmaxWeights(const Eigen::VectorXd& costs, double lambda);
 double quaternionToYaw(const geometry_msgs::msg::Quaternion& quat);
 
 /**
+ * @brief Log-Sum-Exp 계산 (수치 안정성 보장)
+ * @param values 입력 벡터
+ * @return log(sum(exp(values)))
+ *
+ * max-shift trick: log(Σ exp(v_i)) = max + log(Σ exp(v_i - max))
+ */
+double logSumExp(const Eigen::VectorXd& values);
+
+/**
  * @brief Effective Sample Size (ESS) 계산
  * @param weights 가중치 벡터 (정규화됨, 합 = 1)
  * @return ESS 값 [1, K]

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/weight_computation.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/weight_computation.hpp
@@ -1,0 +1,67 @@
+#ifndef MPC_CONTROLLER_ROS2__WEIGHT_COMPUTATION_HPP_
+#define MPC_CONTROLLER_ROS2__WEIGHT_COMPUTATION_HPP_
+
+#include <Eigen/Dense>
+#include <string>
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief MPPI 가중치 계산 Strategy 인터페이스
+ *
+ * Vanilla, Log-MPPI 등 다양한 가중치 계산 방식을 플러그 가능하게 추상화.
+ * 향후 Tsallis, Risk-Aware 등도 동일 패턴으로 추가 가능.
+ */
+class WeightComputation
+{
+public:
+  virtual ~WeightComputation() = default;
+
+  /**
+   * @brief 비용 벡터로부터 정규화된 가중치 계산
+   * @param costs 비용 벡터 (K개 샘플)
+   * @param lambda Temperature 파라미터
+   * @return 정규화된 가중치 벡터 (합 = 1)
+   */
+  virtual Eigen::VectorXd compute(const Eigen::VectorXd& costs, double lambda) const = 0;
+
+  /**
+   * @brief Strategy 이름 반환 (로깅용)
+   */
+  virtual std::string name() const = 0;
+};
+
+/**
+ * @brief Vanilla MPPI 가중치 (기존 softmaxWeights 래핑)
+ *
+ * weights[k] = exp(-costs[k]/lambda) / Sigma exp(-costs[i]/lambda)
+ * max-shift trick 적용으로 수치 안정성 보장.
+ */
+class VanillaMPPIWeights : public WeightComputation
+{
+public:
+  Eigen::VectorXd compute(const Eigen::VectorXd& costs, double lambda) const override;
+  std::string name() const override { return "VanillaMPPI"; }
+};
+
+/**
+ * @brief Log-MPPI 가중치 (log-space 정규화)
+ *
+ * log_w_k = -S_k / lambda
+ * log_w_k -= logSumExp(log_w)  // log-space 정규화
+ * w_k = exp(log_w_k)
+ *
+ * Vanilla와 수학적으로 동일하나, log-space 가중치 조작이 필요한
+ * 후속 확장(importance sampling 보정 등)의 기반 클래스로 활용.
+ */
+class LogMPPIWeights : public WeightComputation
+{
+public:
+  Eigen::VectorXd compute(const Eigen::VectorXd& costs, double lambda) const override;
+  std::string name() const override { return "LogMPPI"; }
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__WEIGHT_COMPUTATION_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
+++ b/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
@@ -56,6 +56,11 @@ def launch_setup(context, *args, **kwargs):
             pkg_dir, 'config', 'nav2_params_nav2_mppi.yaml'
         )
         controller_label = 'nav2 기본 MPPI (nav2_mppi_controller::MPPIController)'
+    elif controller_type == 'log':
+        controller_params_file = os.path.join(
+            pkg_dir, 'config', 'nav2_params_log_mppi.yaml'
+        )
+        controller_label = 'Log-MPPI (mpc_controller_ros2::LogMPPIControllerPlugin)'
     else:
         controller_params_file = os.path.join(
             pkg_dir, 'config', 'nav2_params_custom_mppi.yaml'
@@ -383,7 +388,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'controller',
             default_value='custom',
-            description='MPPI controller type: "custom" (mpc_controller_ros2) or "nav2" (nav2_mppi_controller)'
+            description='MPPI controller type: "custom", "log" (Log-MPPI), or "nav2" (nav2_mppi_controller)'
         ),
 
         # Environment variables

--- a/ros2_ws/src/mpc_controller_ros2/plugins/mppi_controller_plugin.xml
+++ b/ros2_ws/src/mpc_controller_ros2/plugins/mppi_controller_plugin.xml
@@ -6,4 +6,11 @@
       Supports differential drive robots with trajectory tracking and obstacle avoidance.
     </description>
   </class>
+  <class type="mpc_controller_ros2::LogMPPIControllerPlugin" base_class_type="nav2_core::Controller">
+    <description>
+      Log-MPPI controller plugin for nav2.
+      Log-space weight computation variant of MPPI for improved numerical stability.
+      Serves as a base for importance sampling extensions.
+    </description>
+  </class>
 </library>

--- a/ros2_ws/src/mpc_controller_ros2/src/log_mppi_controller_plugin.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/log_mppi_controller_plugin.cpp
@@ -1,0 +1,15 @@
+#include "mpc_controller_ros2/log_mppi_controller_plugin.hpp"
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mpc_controller_ros2::LogMPPIControllerPlugin, nav2_core::Controller)
+
+namespace mpc_controller_ros2
+{
+
+LogMPPIControllerPlugin::LogMPPIControllerPlugin()
+  : MPPIControllerPlugin()
+{
+  weight_computation_ = std::make_unique<LogMPPIWeights>();
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/src/utils.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/utils.cpp
@@ -45,6 +45,12 @@ Eigen::VectorXd softmaxWeights(const Eigen::VectorXd& costs, double lambda)
   return exp_vals / sum;
 }
 
+double logSumExp(const Eigen::VectorXd& values)
+{
+  double max_val = values.maxCoeff();
+  return max_val + std::log((values.array() - max_val).exp().sum());
+}
+
 double quaternionToYaw(const geometry_msgs::msg::Quaternion& quat)
 {
   // Convert quaternion to yaw using atan2

--- a/ros2_ws/src/mpc_controller_ros2/src/weight_computation.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/weight_computation.cpp
@@ -1,0 +1,42 @@
+#include "mpc_controller_ros2/weight_computation.hpp"
+#include "mpc_controller_ros2/utils.hpp"
+
+namespace mpc_controller_ros2
+{
+
+Eigen::VectorXd VanillaMPPIWeights::compute(
+  const Eigen::VectorXd& costs, double lambda) const
+{
+  return softmaxWeights(costs, lambda);
+}
+
+Eigen::VectorXd LogMPPIWeights::compute(
+  const Eigen::VectorXd& costs, double lambda) const
+{
+  // Zero-lambda fallback: greedy (최소 비용 샘플만 선택)
+  if (lambda < 1e-9) {
+    Eigen::VectorXd weights = Eigen::VectorXd::Zero(costs.size());
+    int min_idx;
+    costs.minCoeff(&min_idx);
+    weights(min_idx) = 1.0;
+    return weights;
+  }
+
+  // Log-space 가중치 계산
+  Eigen::VectorXd log_weights = -costs / lambda;
+
+  // Log-space 정규화: log_w -= logSumExp(log_w)
+  log_weights.array() -= logSumExp(log_weights);
+
+  // Exp하여 실제 가중치로 변환
+  Eigen::VectorXd weights = log_weights.array().exp();
+
+  // 수치 오차 대비 재정규화
+  double sum = weights.sum();
+  if (sum < 1e-12) {
+    return Eigen::VectorXd::Constant(costs.size(), 1.0 / costs.size());
+  }
+  return weights / sum;
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/test/unit/test_weight_computation.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/test/unit/test_weight_computation.cpp
@@ -1,0 +1,207 @@
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <cmath>
+
+#include "mpc_controller_ros2/weight_computation.hpp"
+#include "mpc_controller_ros2/utils.hpp"
+
+using namespace mpc_controller_ros2;
+
+// ============================================================
+// logSumExp 테스트
+// ============================================================
+
+TEST(LogSumExpTest, BasicValues)
+{
+  Eigen::VectorXd v(3);
+  v << 1.0, 2.0, 3.0;
+  double result = logSumExp(v);
+  double expected = std::log(std::exp(1.0) + std::exp(2.0) + std::exp(3.0));
+  EXPECT_NEAR(result, expected, 1e-10);
+}
+
+TEST(LogSumExpTest, IdenticalValues)
+{
+  Eigen::VectorXd v = Eigen::VectorXd::Constant(5, 3.0);
+  double result = logSumExp(v);
+  // log(5 * exp(3)) = 3 + log(5)
+  double expected = 3.0 + std::log(5.0);
+  EXPECT_NEAR(result, expected, 1e-10);
+}
+
+TEST(LogSumExpTest, LargeValues)
+{
+  Eigen::VectorXd v(3);
+  v << 1000.0, 1001.0, 999.0;
+  double result = logSumExp(v);
+  // max-shift trick 덕분에 overflow 없이 계산 가능
+  EXPECT_TRUE(std::isfinite(result));
+  EXPECT_GT(result, 1000.0);
+}
+
+TEST(LogSumExpTest, NegativeValues)
+{
+  Eigen::VectorXd v(3);
+  v << -1000.0, -1001.0, -999.0;
+  double result = logSumExp(v);
+  EXPECT_TRUE(std::isfinite(result));
+  EXPECT_LT(result, -998.0);
+}
+
+// ============================================================
+// Vanilla vs Log-MPPI 동등성 테스트
+// ============================================================
+
+TEST(WeightComputationTest, VanillaLogEquivalence)
+{
+  VanillaMPPIWeights vanilla;
+  LogMPPIWeights log_mppi;
+
+  Eigen::VectorXd costs(5);
+  costs << 10.0, 20.0, 15.0, 30.0, 5.0;
+  double lambda = 10.0;
+
+  Eigen::VectorXd vanilla_weights = vanilla.compute(costs, lambda);
+  Eigen::VectorXd log_weights = log_mppi.compute(costs, lambda);
+
+  // 두 방법의 결과가 수치적으로 동일해야 함
+  for (int i = 0; i < costs.size(); ++i) {
+    EXPECT_NEAR(vanilla_weights(i), log_weights(i), 1e-10)
+      << "Mismatch at index " << i;
+  }
+}
+
+TEST(WeightComputationTest, VanillaLogEquivalenceVaryingLambda)
+{
+  VanillaMPPIWeights vanilla;
+  LogMPPIWeights log_mppi;
+
+  Eigen::VectorXd costs(100);
+  for (int i = 0; i < 100; ++i) {
+    costs(i) = static_cast<double>(i) * 0.5;
+  }
+
+  for (double lambda : {0.1, 1.0, 10.0, 100.0}) {
+    Eigen::VectorXd vanilla_weights = vanilla.compute(costs, lambda);
+    Eigen::VectorXd log_weights = log_mppi.compute(costs, lambda);
+
+    for (int i = 0; i < costs.size(); ++i) {
+      EXPECT_NEAR(vanilla_weights(i), log_weights(i), 1e-8)
+        << "Mismatch at index " << i << " with lambda=" << lambda;
+    }
+  }
+}
+
+// ============================================================
+// 정규화 테스트
+// ============================================================
+
+TEST(WeightComputationTest, WeightsSumToOne)
+{
+  VanillaMPPIWeights vanilla;
+  LogMPPIWeights log_mppi;
+
+  Eigen::VectorXd costs(10);
+  for (int i = 0; i < 10; ++i) {
+    costs(i) = static_cast<double>(i) * 3.0 + 1.0;
+  }
+  double lambda = 5.0;
+
+  EXPECT_NEAR(vanilla.compute(costs, lambda).sum(), 1.0, 1e-10);
+  EXPECT_NEAR(log_mppi.compute(costs, lambda).sum(), 1.0, 1e-10);
+}
+
+TEST(WeightComputationTest, WeightsNonNegative)
+{
+  LogMPPIWeights log_mppi;
+
+  Eigen::VectorXd costs(20);
+  for (int i = 0; i < 20; ++i) {
+    costs(i) = static_cast<double>(i) * 10.0;
+  }
+
+  Eigen::VectorXd weights = log_mppi.compute(costs, 1.0);
+  for (int i = 0; i < weights.size(); ++i) {
+    EXPECT_GE(weights(i), 0.0) << "Negative weight at index " << i;
+  }
+}
+
+// ============================================================
+// Zero-lambda fallback (greedy) 테스트
+// ============================================================
+
+TEST(WeightComputationTest, ZeroLambdaGreedy)
+{
+  VanillaMPPIWeights vanilla;
+  LogMPPIWeights log_mppi;
+
+  Eigen::VectorXd costs(5);
+  costs << 10.0, 5.0, 20.0, 3.0, 15.0;  // 인덱스 3이 최소
+
+  Eigen::VectorXd vanilla_weights = vanilla.compute(costs, 0.0);
+  Eigen::VectorXd log_weights = log_mppi.compute(costs, 0.0);
+
+  // 최소 비용 인덱스만 가중치 1.0
+  EXPECT_NEAR(vanilla_weights(3), 1.0, 1e-10);
+  EXPECT_NEAR(log_weights(3), 1.0, 1e-10);
+
+  // 나머지는 0
+  for (int i = 0; i < 5; ++i) {
+    if (i != 3) {
+      EXPECT_NEAR(vanilla_weights(i), 0.0, 1e-10);
+      EXPECT_NEAR(log_weights(i), 0.0, 1e-10);
+    }
+  }
+}
+
+// ============================================================
+// 극단 비용 안정성 테스트
+// ============================================================
+
+TEST(WeightComputationTest, ExtremeCostStability)
+{
+  LogMPPIWeights log_mppi;
+
+  // 극단적으로 큰 비용 차이
+  Eigen::VectorXd costs(3);
+  costs << 0.0, 1e6, 1e6;
+
+  Eigen::VectorXd weights = log_mppi.compute(costs, 1.0);
+
+  EXPECT_TRUE(weights.allFinite()) << "Weights contain NaN or Inf";
+  EXPECT_NEAR(weights.sum(), 1.0, 1e-10);
+  // 최소 비용(인덱스 0)이 거의 모든 가중치를 차지
+  EXPECT_GT(weights(0), 0.99);
+}
+
+TEST(WeightComputationTest, UniformCosts)
+{
+  LogMPPIWeights log_mppi;
+
+  // 모든 비용이 동일하면 균등 가중치
+  Eigen::VectorXd costs = Eigen::VectorXd::Constant(10, 5.0);
+  Eigen::VectorXd weights = log_mppi.compute(costs, 10.0);
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NEAR(weights(i), 0.1, 1e-10);
+  }
+}
+
+// ============================================================
+// Strategy 이름 테스트
+// ============================================================
+
+TEST(WeightComputationTest, StrategyNames)
+{
+  VanillaMPPIWeights vanilla;
+  LogMPPIWeights log_mppi;
+
+  EXPECT_EQ(vanilla.name(), "VanillaMPPI");
+  EXPECT_EQ(log_mppi.name(), "LogMPPI");
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- WeightComputation Strategy 패턴으로 MPPI 가중치 계산을 분리
- Log-MPPI C++ nav2 플러그인 (`LogMPPIControllerPlugin`) 추가
- 12개 단위 테스트 전체 PASS (Vanilla/Log 동등성, 극단 비용 안정성, greedy fallback)

## 아키텍처
```
nav2_core::Controller
       │
  ┌────┴──────────────┐
  │                   │
MPPIControllerPlugin  LogMPPIControllerPlugin
  │ uses              │ uses
  ▼                   ▼
VanillaMPPIWeights   LogMPPIWeights
  └───────┬───────────┘
   WeightComputation (인터페이스)
```

## 변경 파일
### 신규 (6개)
- `weight_computation.hpp/cpp` — Strategy 인터페이스 + Vanilla/Log 구현
- `log_mppi_controller_plugin.hpp/cpp` — Log-MPPI nav2 플러그인
- `nav2_params_log_mppi.yaml` — Log-MPPI 설정 파일
- `test_weight_computation.cpp` — 12개 단위 테스트

### 수정 (5개)
- `utils.hpp/cpp` — `logSumExp()` 추가
- `mppi_controller_plugin.hpp/cpp` — `weight_computation_` Strategy 적용
- `mppi_controller_plugin.xml` — LogMPPI 플러그인 등록
- `CMakeLists.txt` — 빌드 + 테스트 등록
- `mppi_ros2_control_nav2.launch.py` — `controller:=log` 옵션 추가

## Test plan
- [x] `colcon build --packages-select mpc_controller_ros2` 성공
- [x] 12개 단위 테스트 PASS
- [ ] `ros2 launch ... controller:=custom` — Vanilla 기존 동작 확인
- [ ] `ros2 launch ... controller:=log` — Log-MPPI 신규 동작 확인

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)