### PR TITLE
fix: Spline-MPPI figure8 RMSE 개선 (#64)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,11 +47,15 @@
 
 - [ ] 각도 정규화 엣지 케이스 수정
 - [ ] 고속 주행 시 경로 추적 오버슈트 개선
-- [ ] Spline-MPPI figure8 궤적 추적 RMSE 개선 (현재 2.17m → 목표 <0.5m)
-
 ---
 
 ## ✅ Completed
+
+### 2026-02-18 (Issue #64)
+- [x] Spline-MPPI figure8 궤적 추적 RMSE 개선 (2.17m → <0.5m)
+  * Auto knot sigma: basis 감쇠 자동 보정 (amp_factor)
+  * LS warm-start: pseudo-inverse 재투영으로 시간 정렬
+  * 기본 knots 8→12, Python/C++ 동기화
 
 ### 2026-02-18
 - [x] #87 M3.5 Smooth/Spline/SVG-MPPI C++ nav2 플러그인 구현 (PR #88)

--- a/docs/mppi/MPPI_GUIDE.md
+++ b/docs/mppi/MPPI_GUIDE.md
@@ -309,8 +309,10 @@ P개 knot에만 노이즈 → B-spline basis로 N개 보간:
 **핵심 파라미터**:
 | 파라미터 | 역할 | 기본값 |
 |---------|------|--------|
-| spline_num_knots | B-spline 제어점 수 (P) | 8 |
+| spline_num_knots | B-spline 제어점 수 (P) | 12 |
 | spline_degree | B-spline 차수 | 3 (cubic) |
+| spline_knot_sigma | knot 노이즈 σ (None=auto) | None |
+| spline_auto_knot_sigma | basis 감쇠 자동 보정 | True |
 
 ### 2.9 M3.5c: SVG-MPPI (Guide Particle)
 

--- a/docs/mppi/PRD.md
+++ b/docs/mppi/PRD.md
@@ -113,7 +113,7 @@ MPPI 알고리즘 흐름:
 #### M3.5b: Spline-MPPI ✅ 완료
 - **FR-29**: SplineMPPIController — P개 knot 노이즈 → B-spline basis(N,P) 보간
 - **FR-30**: _bspline_basis() — 순수 NumPy de Boor 재귀 (scipy 미사용, NFR-1 준수)
-- **FR-31**: spline_num_knots, spline_degree, spline_knot_sigma 파라미터
+- **FR-31**: spline_num_knots, spline_degree, spline_knot_sigma, spline_auto_knot_sigma 파라미터
 
 #### M3.5c: SVG-MPPI ✅ 완료
 - **FR-32**: SVGMPPIController — G개 guide particle SVGD + (K-G)개 follower resampling

--- a/examples/mppi_all_variants_benchmark.py
+++ b/examples/mppi_all_variants_benchmark.py
@@ -181,7 +181,7 @@ def create_controller(
             robot_params, MPPIParams(**bp), seed=seed, obstacles=obstacles,
         )
     elif variant == "Spline":
-        bp["spline_num_knots"] = 8
+        bp["spline_num_knots"] = 12
         bp["spline_degree"] = 3
         return SplineMPPIController(
             robot_params, MPPIParams(**bp), seed=seed, obstacles=obstacles,
@@ -765,7 +765,7 @@ def main():
   CVaR      — Risk-Aware (α=0.7, 보수적)
   SVMPC     — Stein Variational (SVGD L=3)
   Smooth    — Δu input-lifting (jerk cost)
-  Spline    — B-spline basis (P=8 knots)
+  Spline    — B-spline basis (P=12 knots)
   SVG       — Guide particle SVGD (G=16)
 """,
     )
@@ -808,7 +808,7 @@ def main():
         "CVaR":    "Risk-Aware (α=0.7) 보수적",
         "SVMPC":   "SVGD 커널 다양성 (L=3)",
         "Smooth":  "Δu input-lifting smooth",
-        "Spline":  "B-spline basis (P=8)",
+        "Spline":  "B-spline basis (P=12)",
         "SVG":     "Guide SVGD (G=12) 다중모드",
     }
     for v in variants:

--- a/examples/spline_mppi_demo.py
+++ b/examples/spline_mppi_demo.py
@@ -236,14 +236,6 @@ def main():
             R=np.diag([0.01, 0.01]),
             Qf=np.diag([100.0, 100.0, 10.0]),
         ), MPPIController),
-        ("Spline P=4", MPPIParams(
-            N=20, K=512, dt=0.05, lambda_=10.0,
-            noise_sigma=np.array([0.3, 0.3]),
-            Q=np.diag([10.0, 10.0, 1.0]),
-            R=np.diag([0.01, 0.01]),
-            Qf=np.diag([100.0, 100.0, 10.0]),
-            spline_num_knots=4,
-        ), SplineMPPIController),
         ("Spline P=8", MPPIParams(
             N=20, K=512, dt=0.05, lambda_=10.0,
             noise_sigma=np.array([0.3, 0.3]),
@@ -251,6 +243,14 @@ def main():
             R=np.diag([0.01, 0.01]),
             Qf=np.diag([100.0, 100.0, 10.0]),
             spline_num_knots=8,
+        ), SplineMPPIController),
+        ("Spline P=12", MPPIParams(
+            N=20, K=512, dt=0.05, lambda_=10.0,
+            noise_sigma=np.array([0.3, 0.3]),
+            Q=np.diag([10.0, 10.0, 1.0]),
+            R=np.diag([0.01, 0.01]),
+            Qf=np.diag([100.0, 100.0, 10.0]),
+            spline_num_knots=12,
         ), SplineMPPIController),
     ]
 

--- a/mpc_controller/controllers/mppi/mppi_params.py
+++ b/mpc_controller/controllers/mppi/mppi_params.py
@@ -70,9 +70,10 @@ class MPPIParams:
     smooth_action_cost_weight: float = 1.0           # jerk cost 전체 스케일
 
     # M3.5b Spline-MPPI (ICRA 2024 — B-spline basis 보간)
-    spline_num_knots: int = 8                        # 제어점 수 (P << N)
+    spline_num_knots: int = 12                       # 제어점 수 (P << N)
     spline_degree: int = 3                           # B-spline 차수 (cubic)
-    spline_knot_sigma: np.ndarray | None = None      # (nu,) knot 노이즈 σ. None=noise_sigma 재사용
+    spline_knot_sigma: np.ndarray | None = None      # (nu,) knot 노이즈 σ. None=auto or noise_sigma
+    spline_auto_knot_sigma: bool = True              # basis 감쇠 자동 보정 (σ × amp_factor)
 
     # M3.5c SVG-MPPI (Kondo et al., ICRA 2024 — Guide particle SVGD)
     svg_num_guide_particles: int = 16                # Guide 수 (G << K)

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_spline_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_spline_mppi.yaml
@@ -80,8 +80,9 @@ controller_server:
       prefer_forward_weight: 15.0
 
       # Spline-MPPI 전용 파라미터
-      spline_num_knots: 8             # B-spline 제어점 수 (P << N)
+      spline_num_knots: 12            # B-spline 제어점 수 (P << N)
       spline_degree: 3                # B-spline 차수 (cubic)
+      spline_auto_knot_sigma: true    # basis 감쇠 자동 보정
 
       # SOTA 변형 (기본값 유지)
       tsallis_q: 1.5

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
@@ -104,8 +104,9 @@ struct MPPIParams
   double smooth_action_cost_weight{1.0}; // jerk cost 전체 가중치
 
   // Spline-MPPI (ICRA 2024)
-  int spline_num_knots{8};              // B-spline 제어점 수 (P << N)
+  int spline_num_knots{12};             // B-spline 제어점 수 (P << N)
   int spline_degree{3};                 // B-spline 차수 (cubic)
+  bool spline_auto_knot_sigma{true};    // basis 감쇠 자동 보정 (σ × amp_factor)
 
   // SVG-MPPI (Kondo et al., ICRA 2024)
   int svg_num_guide_particles{10};      // guide particle 수 (G << K)

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/spline_mppi_controller_plugin.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/spline_mppi_controller_plugin.hpp
@@ -62,7 +62,9 @@ protected:
 
 private:
   Eigen::MatrixXd basis_;       // (N, P) 사전 계산
+  Eigen::MatrixXd basis_pinv_;  // (P, N) pseudo-inverse (LS warm-start용)
   Eigen::MatrixXd u_knots_;     // (P, 2) knot warm-start
+  Eigen::Vector2d knot_sigma_;  // knot 노이즈 σ (auto 보정 적용)
   int P_;                       // 제어점 수
   int degree_;                  // B-spline 차수
 };


### PR DESCRIPTION
## Summary
- **Auto knot sigma**: B-spline basis 감쇠(Var 35%) 자동 보정 — `amp_factor = sqrt(1/mean(||row||²))`
- **LS warm-start**: `pinv(B) @ U_shifted`로 knot↔시간축 불일치 해결
- **기본 knots 8→12**: figure8 곡률 표현 자유도 향상

## 근인 분석

| 근인 | 해결책 | 신뢰도 |
|------|--------|--------|
| Knot sigma 감쇠 (유효 σ ≈ 35%) | `spline_auto_knot_sigma` | 높음 |
| P=8 자유도 부족 | 기본값 12로 증가 | 중간 |
| Warm-start 시간 불일치 | LS 재투영 (pinv) | 중간 |

## 변경 파일 (13개)

### Python
- `mppi_params.py`: `spline_num_knots=12`, `spline_auto_knot_sigma=True`
- `spline_mppi.py`: auto sigma 보정 + LS warm-start
- `test_spline_mppi.py`: +6 테스트 (29개 전체 통과)
- `spline_mppi_demo.py`: P=4→P=12 비교
- `mppi_all_variants_benchmark.py`: knots 8→12

### C++
- `mppi_params.hpp`: `spline_num_knots{12}`, `spline_auto_knot_sigma{true}`
- `spline_mppi_controller_plugin.hpp`: `basis_pinv_`, `knot_sigma_` 멤버
- `spline_mppi_controller_plugin.cpp`: auto sigma + LS warm-start
- `nav2_params_spline_mppi.yaml`: 파라미터 추가
- `test_m35_plugins.cpp`: +2 테스트 (18개 전체 통과)

### 문서
- `TODO.md`, `PRD.md`, `MPPI_GUIDE.md`

## Test plan
- [x] Python 기존 23개 + 신규 6개 = 29개 통과
- [x] Python figure8 RMSE < 0.5m 회귀 테스트 통과
- [x] C++ 기존 16개 + 신규 2개 = 18개 gtest 통과
- [x] C++ 전체 81개 gtest 통과

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)