### PR TITLE
feat: MPPI nav2 플러그인 동작 품질 개선

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_custom_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_custom_mppi.yaml
@@ -67,8 +67,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate) ★ nav2에 없는 고유 기능
       R_rate_v: 1.0
@@ -80,13 +80,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # Visualization
       visualize_samples: true

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_log_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_log_mppi.yaml
@@ -68,8 +68,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -81,13 +81,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # Visualization
       visualize_samples: true

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_risk_aware_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_risk_aware_mppi.yaml
@@ -73,8 +73,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -86,13 +86,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # Visualization
       visualize_samples: true

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_smooth_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_smooth_mppi.yaml
@@ -66,8 +66,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -79,13 +79,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # Smooth-MPPI 전용 파라미터
       smooth_R_jerk_v: 0.1            # jerk weight (v 방향)

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_spline_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_spline_mppi.yaml
@@ -66,8 +66,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -79,13 +79,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # Spline-MPPI 전용 파라미터
       spline_num_knots: 12            # B-spline 제어점 수 (P << N)

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_svg_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_svg_mppi.yaml
@@ -66,8 +66,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -79,13 +79,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # SVG-MPPI 전용 파라미터
       svg_num_guide_particles: 10     # guide particle 수 (G << K)

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_svmpc.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_svmpc.yaml
@@ -67,8 +67,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -80,13 +80,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # SVMPC 전용 파라미터
       svgd_num_iterations: 3       # SVGD 반복 횟수 (0=Vanilla, 권장: 1~5)

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_tsallis_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_tsallis_mppi.yaml
@@ -73,8 +73,8 @@ controller_server:
       Qf_theta: 2.0
 
       # Control effort weights (R)
-      R_v: 0.1
-      R_omega: 0.1
+      R_v: 0.5
+      R_omega: 0.3
 
       # Control rate weights (R_rate)
       R_rate_v: 1.0
@@ -86,13 +86,22 @@ controller_server:
 
       # Costmap obstacle cost
       use_costmap_cost: true
-      costmap_lethal_cost: 1000.0
-      costmap_critical_cost: 100.0
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
       lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
 
       # Forward preference (후진 페널티)
-      prefer_forward_weight: 50.0
+      prefer_forward_weight: 10.0
       prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature (ESS 기반 자동 조정)
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
 
       # Visualization
       visualize_samples: true

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_controller_plugin.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_controller_plugin.hpp
@@ -148,6 +148,8 @@ private:
   Eigen::MatrixXd nominal_trajectory_;  // N+1 x 3 (Tube-MPPI용)
   double speed_limit_{1.0};
   bool speed_limit_valid_{false};
+  Eigen::Vector2d current_velocity_{0.0, 0.0};  // [v, omega] 현재 속도
+  double goal_dist_{std::numeric_limits<double>::max()};  // 목표까지 남은 거리
 
   // CostmapObstacleCost 비소유 포인터 (cost_function_ 내부 소유)
   CostmapObstacleCost* costmap_obstacle_cost_ptr_{nullptr};

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
@@ -122,6 +122,8 @@ struct MPPIParams
   double costmap_lethal_cost{1000.0};   // LETHAL 셀 비용
   double costmap_critical_cost{100.0};  // INSCRIBED 셀 비용
   double lookahead_dist{0.0};           // 0 = auto (v_max * N * dt)
+  double min_lookahead{0.5};            // 동적 lookahead 최소값 (m)
+  double goal_slowdown_dist{1.0};       // 목표 접근 감속 시작 거리 (m)
 
   // Visualization
   bool visualize_samples{true};           // 샘플 궤적 표시


### PR DESCRIPTION
## Summary

Closes #93

MPPI nav2 플러그인의 **경로 추종 정밀도, 목표 도달, 부드러움**을 개선합니다.

- heading: waypoint orientation → 경로 접선(atan2) + goal heading 블렌딩
- velocity 활용: 동적 lookahead (속도 비례, min=0.5m ~ max=v_max*N*dt)
- warm-start: 마지막 스텝 이전 값 유지 (급감속 방지)
- goal approach: 거리 비례 감속 + noise sigma 스케일링
- adaptive temperature: 기본 활성화 (ESS 50% 목표)
- 비용 가중치 재조정 (8개 yaml): prefer_forward 50→10, costmap_lethal 1000→500, R_v 0.1→0.5

```
BEFORE                               AFTER
─────────────────────────            ─────────────────────────
Heading: waypoint orientation        Heading: path tangent (atan2)
Lookahead: 1.5m 고정                 Lookahead: 속도 비례 (0.5~1.5m)
Warm-start: 마지막=0                 Warm-start: 마지막=이전값
Temperature: λ=10 고정               Temperature: ESS 기반 자동 조정
Cost balance: 장애물 >> 제어          Cost balance: 장애물 ≈ 추적 > 제어
Goal approach: 감속 없음              Goal approach: 거리 비례 감속
```

## Test plan

- [x] colcon build 성공 (error 없음)
- [x] 130개 gtest 전체 통과 (9개 test suite, 0 failures)
- [ ] RVIZ에서 곡선 구간 heading 확인
- [ ] 목표 접근 시 감속 + 정밀 정지 확인
- [ ] 샘플 궤적 분포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)