### PR TITLE
ci: GitHub Actions ROS2 C++ CI — 211 gtest 자동화

### DIFF
--- a/.github/workflows/ros2-ci.yml
+++ b/.github/workflows/ros2-ci.yml
@@ -1,0 +1,67 @@
+name: ROS2 C++ CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'ros2_ws/src/mpc_controller_ros2/**'
+      - '.github/workflows/ros2-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ros2_ws/src/mpc_controller_ros2/**'
+      - '.github/workflows/ros2-ci.yml'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-24.04
+    container:
+      image: ros:jazzy
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          apt-get update -q
+          apt-get install -y -q --no-install-recommends \
+            libeigen3-dev \
+            ros-jazzy-nav2-core \
+            ros-jazzy-nav2-costmap-2d \
+            ros-jazzy-nav2-util \
+            ros-jazzy-nav2-msgs \
+            ros-jazzy-tf2-ros \
+            ros-jazzy-tf2-geometry-msgs \
+            ros-jazzy-pluginlib \
+            ros-jazzy-ament-cmake-gtest \
+            ros-jazzy-ament-lint-auto
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Build
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          cd ros2_ws
+          colcon build --packages-select mpc_controller_ros2 \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release
+        env:
+          MAKEFLAGS: "-j$(nproc)"
+
+      - name: Run C++ tests
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          cd ros2_ws
+          source install/setup.bash
+          colcon test --packages-select mpc_controller_ros2 \
+            --event-handlers console_cohesion+ \
+            --ctest-args -R "^test_" --exclude-regex "test_mpc_controller_node" \
+            --return-code-on-test-failure
+
+      - name: Show test results
+        if: always()
+        run: |
+          cd ros2_ws
+          colcon test-result --all --verbose || true


### PR DESCRIPTION
## Summary

- ROS2 Jazzy Docker (`ros:jazzy`) 기반 CI 파이프라인
- PR/push to main 시 자동 `colcon build` + `colcon test`
- 12개 테스트 스위트, 211개 gtest 실행
- `ros2_ws/` 경로 변경 시에만 트리거 (불필요한 빌드 방지)

## Workflow

```
push/PR → ros:jazzy container → apt install deps → colcon build → colcon test
                                                                      ↓
                                                    ❌ fail → PR block
                                                    ✅ pass → mergeable
```

## Test plan

- [x] workflow 파일 생성
- [ ] GitHub Actions에서 빌드 성공 확인
- [ ] 211개 gtest 통과 확인

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)