### PR TITLE
feat: MPPI 8종 변형 GPU 지원 확장 (#104)

### DIFF
--- a/mpc_controller/controllers/mppi/base_mppi.py
+++ b/mpc_controller/controllers/mppi/base_mppi.py
@@ -150,6 +150,7 @@ class MPPIController:
             model_name="diff_drive",
             use_float32=self.params.gpu_float32,
             warmup=self.params.gpu_warmup,
+            weight_fn=self._get_gpu_weight_fn(),
         )
         self._to_jax = to_jax
         logger.info(f"GPU MPPI initialized (backend: {get_backend_name()})")
@@ -365,6 +366,11 @@ class MPPIController:
     def _compute_weights(self, costs: np.ndarray) -> np.ndarray:
         """비용에서 가중치 계산. 서브클래스에서 오버라이드 가능."""
         return softmax_weights(costs, self._get_current_lambda())
+
+    def _get_gpu_weight_fn(self):
+        """GPU 가중치 함수 반환. 서브클래스에서 오버라이드."""
+        from mpc_controller.controllers.mppi.gpu_weights import vanilla_softmax_weights
+        return vanilla_softmax_weights
 
     def reset(self) -> None:
         """제어열 초기화 및 반복 횟수 리셋."""

--- a/mpc_controller/controllers/mppi/gpu_backend.py
+++ b/mpc_controller/controllers/mppi/gpu_backend.py
@@ -51,8 +51,8 @@ def to_jax(arr: np.ndarray, dtype=None):
 
 
 def to_numpy(arr) -> np.ndarray:
-    """JAX 배열 → NumPy 배열 변환."""
-    return np.asarray(arr)
+    """JAX 배열 → NumPy 배열 변환 (writable copy)."""
+    return np.array(arr)
 
 
 def get_dtype(use_float32: bool = False):

--- a/mpc_controller/controllers/mppi/gpu_svgd.py
+++ b/mpc_controller/controllers/mppi/gpu_svgd.py
@@ -1,0 +1,107 @@
+"""JAX JIT SVGD 커널 — SVMPC/SVG-MPPI 공유.
+
+Stein Variational Gradient Descent (gradient-free 근사) GPU 구현.
+K×K pairwise 커널 → attractive + repulsive force.
+
+메모리 제한: K=4096 → (K,K,D) ≈ 8GB. K≤2048 권장.
+"""
+
+import jax
+import jax.numpy as jnp
+
+
+@jax.jit
+def svgd_step_jit(particles, weights, bandwidth, step_size):
+    """SVGD 1 iteration (GPU).
+
+    Args:
+        particles: (K, D) 입자 배열
+        weights: (K,) softmax 가중치
+        bandwidth: h (커널 폭)
+        step_size: SVGD 업데이트 step size
+
+    Returns:
+        (K, D) 업데이트된 입자
+    """
+    K = particles.shape[0]
+
+    # pairwise diff: diff[j,i] = x_j - x_i → (K, K, D)
+    diff = particles[:, None, :] - particles[None, :, :]
+    sq_dist = jnp.sum(diff ** 2, axis=-1)  # (K, K)
+
+    # RBF 커널
+    kernel = jnp.exp(-sq_dist / (2.0 * bandwidth ** 2))  # (K, K)
+
+    # Attractive force: 저비용 샘플 방향으로 끌어당김
+    # attract_i = Σ_j w_j · k(x_j, x_i) · (x_j - x_i)
+    weighted_kernel = weights[:, None] * kernel  # (K, K)
+    attractive = jnp.einsum("ji,jid->id", weighted_kernel, diff)  # (K, D)
+
+    # Repulsive force: 샘플 간 다양성 유지
+    # repel_i = (1/K) Σ_j k(x_j, x_i) · (x_j - x_i) / h²
+    repulsive = jnp.einsum("ji,jid->id", kernel, diff) / (K * bandwidth ** 2)
+
+    return particles + step_size * (attractive + repulsive)
+
+
+@jax.jit
+def median_bandwidth_jit(particles):
+    """Median heuristic bandwidth (GPU).
+
+    h = sqrt(median(‖x_i - x_j‖²) / (2·log(K+1)))
+
+    Args:
+        particles: (K, D)
+
+    Returns:
+        bandwidth 스칼라 (최소 1e-6)
+    """
+    diff = particles[:, None, :] - particles[None, :, :]
+    sq_dist = jnp.sum(diff ** 2, axis=-1)  # (K, K)
+    K = particles.shape[0]
+
+    # 상삼각 mask (JIT 호환: boolean index 대신 where + sort)
+    mask = jnp.triu(jnp.ones((K, K)), k=1)
+    # 하삼각/대각 → 큰 값으로 치환 후 sort로 median 추출
+    masked_sq = jnp.where(mask > 0, sq_dist, jnp.finfo(sq_dist.dtype).max)
+    flat = masked_sq.ravel()
+    sorted_flat = jnp.sort(flat)
+    n_pairs = K * (K - 1) // 2
+    med = sorted_flat[n_pairs // 2]
+
+    h = jnp.sqrt(med / (2.0 * jnp.log(K + 1.0)))
+    return jnp.maximum(h, 1e-6)
+
+
+@jax.jit
+def compute_diversity_jit(particles):
+    """샘플 다양성 측정 — 평균 pairwise L2 거리 (GPU).
+
+    Args:
+        particles: (K, D)
+
+    Returns:
+        평균 pairwise L2 거리 스칼라
+    """
+    K = particles.shape[0]
+    diff = particles[:, None, :] - particles[None, :, :]
+    dists = jnp.sqrt(jnp.sum(diff ** 2, axis=-1))  # (K, K)
+    mask = jnp.triu(jnp.ones((K, K), dtype=bool), k=1)
+    n_pairs = K * (K - 1) / 2.0
+    return jnp.sum(dists * mask) / jnp.maximum(n_pairs, 1.0)
+
+
+@jax.jit
+def rbf_kernel_jit(particles, bandwidth):
+    """RBF 커널 행렬 (GPU).
+
+    Args:
+        particles: (K, D)
+        bandwidth: h
+
+    Returns:
+        (K, K) 커널 행렬
+    """
+    diff = particles[:, None, :] - particles[None, :, :]
+    sq_dist = jnp.sum(diff ** 2, axis=-1)
+    return jnp.exp(-sq_dist / (2.0 * bandwidth ** 2))

--- a/mpc_controller/controllers/mppi/gpu_weights.py
+++ b/mpc_controller/controllers/mppi/gpu_weights.py
@@ -1,0 +1,139 @@
+"""JAX JIT 가중치 함수 — 변형별 GPU Strategy.
+
+순수 함수 Strategy 패턴: JAX JIT 호환 (클래스 인스턴스는 tracer 추적 불가).
+closure로 파라미터 캡처 → JIT 재컴파일 방지.
+
+┌──────────────────┬───────────────────────────────────────┐
+│ 변형             │ 가중치 함수                           │
+├──────────────────┼───────────────────────────────────────┤
+│ Vanilla          │ vanilla_softmax_weights               │
+│ Log-MPPI         │ log_softmax_weights                   │
+│ Tsallis-MPPI     │ make_tsallis_weights(q) → closure     │
+│ Risk-Aware(CVaR) │ make_cvar_weights(alpha, K) → closure │
+└──────────────────┴───────────────────────────────────────┘
+"""
+
+import jax
+import jax.numpy as jnp
+
+
+@jax.jit
+def vanilla_softmax_weights(costs, lambda_):
+    """Vanilla softmax 가중치 (JAX).
+
+    w_k = exp(-S_k / λ) / Σ exp(-S_j / λ)
+
+    Args:
+        costs: (K,) 비용 배열
+        lambda_: 온도 파라미터
+
+    Returns:
+        (K,) 정규화된 가중치
+    """
+    shifted = -costs / lambda_
+    shifted = shifted - jnp.max(shifted)
+    exp_vals = jnp.exp(shifted)
+    return exp_vals / jnp.sum(exp_vals)
+
+
+@jax.jit
+def log_softmax_weights(costs, lambda_):
+    """Log-space softmax 가중치 (JAX).
+
+    log-space에서 계산하여 극단 cost(1e15)에서 NaN/Inf 방지.
+    logsumexp로 수치 안정성 보장.
+
+    Args:
+        costs: (K,) 비용 배열
+        lambda_: 온도 파라미터
+
+    Returns:
+        (K,) 정규화된 가중치
+    """
+    log_w = -costs / lambda_
+    log_w = log_w - jax.scipy.special.logsumexp(log_w)
+    return jnp.exp(log_w)
+
+
+def make_tsallis_weights(q):
+    """Tsallis q-exponential 가중치 함수 팩토리.
+
+    q를 closure로 캡처 → JIT 재컴파일 방지.
+    q=1.0 → Shannon (Vanilla), q>1 → heavy-tail, q<1 → light-tail.
+
+    Args:
+        q: Tsallis 파라미터
+
+    Returns:
+        JIT 컴파일된 가중치 함수 (costs, lambda_) → (K,)
+    """
+    @jax.jit
+    def tsallis_weights(costs, lambda_):
+        centered = costs - jnp.min(costs)
+        x = -centered / lambda_
+        base = 1.0 + (1.0 - q) * x
+        exponent = 1.0 / (1.0 - q)
+        raw = jnp.where(base > 0, jnp.power(base, exponent), 0.0)
+        total = jnp.sum(raw)
+        return jnp.where(total > 0, raw / total, jnp.ones_like(costs) / costs.shape[0])
+
+    return tsallis_weights
+
+
+def make_cvar_weights(alpha, K):
+    """CVaR 가중치 함수 팩토리.
+
+    alpha, K를 closure로 캡처 → n_keep 정적 결정.
+    최저 비용 ceil(α·K)개만 선택하여 softmax.
+
+    Args:
+        alpha: CVaR 절단 비율 (1.0=전체, <1=risk-averse)
+        K: 샘플 수
+
+    Returns:
+        JIT 컴파일된 가중치 함수 (costs, lambda_) → (K,)
+    """
+    n_keep = max(1, int(jnp.ceil(alpha * K)))
+    # alpha >= 1.0이면 전체 사용
+    if alpha >= 1.0 or n_keep >= K:
+        return vanilla_softmax_weights
+
+    @jax.jit
+    def cvar_weights(costs, lambda_):
+        # 최저비용 n_keep개 선택: top_k(-costs)
+        neg_costs = -costs
+        _, keep_idx = jax.lax.top_k(neg_costs, n_keep)
+        mask = jnp.zeros(K).at[keep_idx].set(1.0)
+        shifted = -costs / lambda_
+        shifted = shifted - jnp.max(shifted)
+        exp_vals = jnp.exp(shifted) * mask
+        return exp_vals / jnp.sum(exp_vals)
+
+    return cvar_weights
+
+
+# ─── Registry ───
+
+WEIGHT_FN_REGISTRY = {
+    "vanilla": vanilla_softmax_weights,
+    "log": log_softmax_weights,
+}
+
+
+def get_weight_fn(name, **params):
+    """이름으로 가중치 함수 조회.
+
+    Args:
+        name: "vanilla", "log", "tsallis", "cvar"
+        **params: make_tsallis_weights(q=...), make_cvar_weights(alpha=..., K=...)
+
+    Returns:
+        JIT 컴파일된 가중치 함수
+    """
+    if name in WEIGHT_FN_REGISTRY:
+        return WEIGHT_FN_REGISTRY[name]
+    if name == "tsallis":
+        return make_tsallis_weights(params.get("q", 1.0))
+    if name == "cvar":
+        return make_cvar_weights(params.get("alpha", 1.0), params.get("K", 1024))
+    raise ValueError(f"Unknown weight function: {name}")

--- a/mpc_controller/controllers/mppi/log_mppi.py
+++ b/mpc_controller/controllers/mppi/log_mppi.py
@@ -39,3 +39,8 @@ class LogMPPIController(MPPIController):
         log_weights = -costs / lambda_
         log_weights -= log_sum_exp(log_weights)  # log-space 정규화
         return np.exp(log_weights)
+
+    def _get_gpu_weight_fn(self):
+        """GPU log-softmax 가중치 함수."""
+        from mpc_controller.controllers.mppi.gpu_weights import log_softmax_weights
+        return log_softmax_weights

--- a/mpc_controller/controllers/mppi/risk_aware_mppi.py
+++ b/mpc_controller/controllers/mppi/risk_aware_mppi.py
@@ -63,3 +63,8 @@ class RiskAwareMPPIController(MPPIController):
         weights = np.zeros(K)
         weights[keep_indices] = selected_weights
         return weights
+
+    def _get_gpu_weight_fn(self):
+        """GPU CVaR 가중치 함수."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_cvar_weights
+        return make_cvar_weights(self.params.cvar_alpha, self.params.K)

--- a/mpc_controller/controllers/mppi/tsallis_mppi.py
+++ b/mpc_controller/controllers/mppi/tsallis_mppi.py
@@ -41,3 +41,8 @@ class TsallisMPPIController(MPPIController):
         if total == 0.0:
             return np.ones_like(costs) / len(costs)
         return raw / total
+
+    def _get_gpu_weight_fn(self):
+        """GPU Tsallis q-exponential 가중치 함수."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_tsallis_weights
+        return make_tsallis_weights(self.params.tsallis_q)

--- a/tests/test_gpu_svgd.py
+++ b/tests/test_gpu_svgd.py
@@ -1,0 +1,172 @@
+"""GPU SVGD 커널 단위 테스트.
+
+SVGD JIT 함수 (svgd_step, median_bandwidth, diversity) 검증.
+CPU utils 함수와 수치 일치 확인.
+"""
+
+import numpy as np
+import pytest
+
+try:
+    import jax
+    import jax.numpy as jnp
+
+    jax.config.update("jax_enable_x64", True)
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not JAX_AVAILABLE, reason="JAX not installed")
+
+
+@pytest.fixture
+def particles():
+    """테스트 입자 (K=32, D=10)."""
+    np.random.seed(123)
+    return jnp.array(np.random.randn(32, 10))
+
+
+@pytest.fixture
+def weights():
+    """테스트 가중치 (K=32)."""
+    np.random.seed(456)
+    w = np.random.rand(32)
+    w /= w.sum()
+    return jnp.array(w)
+
+
+class TestSVGDStep:
+    """svgd_step_jit 검증."""
+
+    def test_output_shape(self, particles, weights):
+        """출력 shape == 입력 shape."""
+        from mpc_controller.controllers.mppi.gpu_svgd import svgd_step_jit
+
+        updated = svgd_step_jit(particles, weights, 1.0, 0.1)
+        assert updated.shape == particles.shape
+
+    def test_attractive_direction(self):
+        """매력력: 저비용(고가중치) 샘플 방향으로 이동."""
+        from mpc_controller.controllers.mppi.gpu_svgd import svgd_step_jit
+
+        # 2개 입자: p0=[0,0](고가중치), p1=[1,0](저가중치)
+        p = jnp.array([[0.0, 0.0], [1.0, 0.0]])
+        w = jnp.array([0.9, 0.1])  # p0가 저비용
+        h = 1.0
+        step = 0.1
+
+        updated = svgd_step_jit(p, w, h, step)
+
+        # p1은 p0 방향(왼쪽)으로 이동해야 함
+        assert float(updated[1, 0]) < 1.0
+
+    def test_repulsive_force(self):
+        """반발력: 동일 위치 입자가 서로 밀어냄."""
+        from mpc_controller.controllers.mppi.gpu_svgd import svgd_step_jit
+
+        # 3개 입자 동일 위치 + 1개 다른 위치
+        p = jnp.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [5.0, 0.0]])
+        w = jnp.array([0.25, 0.25, 0.25, 0.25])
+        h = 1.0
+        step = 0.5
+
+        updated = svgd_step_jit(p, w, h, step)
+
+        # 동일 위치 3개가 분산되어야 함 (완전히 동일하지 않을 수 있음)
+        # 적어도 step > 0이면 업데이트가 발생
+        total_movement = jnp.sum(jnp.abs(updated - p))
+        assert float(total_movement) > 0
+
+    def test_step_size_zero_no_change(self, particles, weights):
+        """step_size=0 → 변화 없음."""
+        from mpc_controller.controllers.mppi.gpu_svgd import svgd_step_jit
+
+        updated = svgd_step_jit(particles, weights, 1.0, 0.0)
+        np.testing.assert_allclose(
+            np.asarray(updated), np.asarray(particles), atol=1e-12
+        )
+
+
+class TestMedianBandwidth:
+    """median_bandwidth_jit 검증."""
+
+    def test_positive_output(self, particles):
+        """bandwidth > 0."""
+        from mpc_controller.controllers.mppi.gpu_svgd import median_bandwidth_jit
+
+        h = median_bandwidth_jit(particles)
+        assert float(h) > 0
+
+    def test_matches_cpu(self, particles):
+        """GPU bandwidth ≈ CPU bandwidth (sort 기반 근사 → rtol=1e-3)."""
+        from mpc_controller.controllers.mppi.gpu_svgd import median_bandwidth_jit
+        from mpc_controller.controllers.mppi.utils import median_bandwidth
+
+        gpu_h = float(np.asarray(median_bandwidth_jit(particles)))
+        cpu_h = median_bandwidth(np.asarray(particles))
+
+        np.testing.assert_allclose(gpu_h, cpu_h, rtol=1e-3)
+
+    def test_identical_particles_min_value(self):
+        """동일 입자 → bandwidth = 1e-6 (최소 보장)."""
+        from mpc_controller.controllers.mppi.gpu_svgd import median_bandwidth_jit
+
+        p = jnp.ones((10, 5))
+        h = median_bandwidth_jit(p)
+        assert float(h) >= 1e-6
+
+
+class TestDiversity:
+    """compute_diversity_jit 검증."""
+
+    def test_single_point_zero(self):
+        """단일 입자 → diversity = 0."""
+        from mpc_controller.controllers.mppi.gpu_svgd import compute_diversity_jit
+
+        p = jnp.array([[1.0, 2.0, 3.0]])
+        d = compute_diversity_jit(p)
+        assert float(d) == 0.0
+
+    def test_identical_points_zero(self):
+        """동일 입자들 → diversity = 0."""
+        from mpc_controller.controllers.mppi.gpu_svgd import compute_diversity_jit
+
+        p = jnp.ones((10, 5))
+        d = compute_diversity_jit(p)
+        np.testing.assert_allclose(float(d), 0.0, atol=1e-10)
+
+    def test_spread_points_positive(self, particles):
+        """분산된 입자 → diversity > 0."""
+        from mpc_controller.controllers.mppi.gpu_svgd import compute_diversity_jit
+
+        d = compute_diversity_jit(particles)
+        assert float(d) > 0
+
+
+class TestRBFKernel:
+    """rbf_kernel_jit 검증."""
+
+    def test_matches_cpu(self, particles):
+        """GPU RBF == CPU RBF."""
+        from mpc_controller.controllers.mppi.gpu_svgd import rbf_kernel_jit
+        from mpc_controller.controllers.mppi.utils import rbf_kernel
+
+        h = 1.0
+        gpu_k = np.asarray(rbf_kernel_jit(particles, h))
+        cpu_k = rbf_kernel(np.asarray(particles), h)
+
+        np.testing.assert_allclose(gpu_k, cpu_k, rtol=1e-10)
+
+    def test_diagonal_is_one(self, particles):
+        """대각선 = 1.0 (자기 자신 커널)."""
+        from mpc_controller.controllers.mppi.gpu_svgd import rbf_kernel_jit
+
+        k = rbf_kernel_jit(particles, 1.0)
+        np.testing.assert_allclose(np.asarray(jnp.diag(k)), 1.0, atol=1e-12)
+
+    def test_symmetric(self, particles):
+        """커널 행렬 대칭."""
+        from mpc_controller.controllers.mppi.gpu_svgd import rbf_kernel_jit
+
+        k = rbf_kernel_jit(particles, 1.0)
+        np.testing.assert_allclose(np.asarray(k), np.asarray(k.T), atol=1e-12)

--- a/tests/test_gpu_variants.py
+++ b/tests/test_gpu_variants.py
@@ -1,0 +1,454 @@
+"""GPU MPPI 변형 통합 테스트 — 8종 GPU vs CPU.
+
+각 변형의 GPU 경로가 정상 동작하는지 검증:
+1. use_gpu=True 생성 + compute_control 정상 반환
+2. 연속 5회 호출 수렴 (발산 없음)
+3. weights-only 변형: GPU weight == CPU weight
+"""
+
+import numpy as np
+import pytest
+
+try:
+    import jax
+    import jax.numpy as jnp
+
+    jax.config.update("jax_enable_x64", True)
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not JAX_AVAILABLE, reason="JAX not installed")
+
+from mpc_controller.models.differential_drive import RobotParams
+from mpc_controller.controllers.mppi.mppi_params import MPPIParams
+
+
+# ─── 공통 Fixtures ───
+
+@pytest.fixture
+def robot_params():
+    return RobotParams()
+
+
+@pytest.fixture
+def state():
+    return np.array([0.0, 0.0, 0.0])
+
+
+@pytest.fixture
+def reference():
+    """직선 참조 궤적 (N+1=31 스텝)."""
+    N = 30
+    ref = np.zeros((N + 1, 3))
+    for t in range(N + 1):
+        ref[t, 0] = t * 0.05
+    return ref
+
+
+# ═══════════════════════════════════════════════════════════════
+# Vanilla GPU (기존 — 회귀 확인)
+# ═══════════════════════════════════════════════════════════════
+
+class TestVanillaGPU:
+    """Vanilla MPPI GPU 회귀 테스트."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.base_mppi import MPPIController
+
+        params = MPPIParams(K=128, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = MPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.base_mppi import MPPIController
+
+        params = MPPIParams(K=256, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = MPPIController(robot_params, params, seed=42)
+
+        costs = []
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            costs.append(info["cost"])
+
+        # 발산하지 않음
+        assert all(np.isfinite(c) for c in costs)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Log-MPPI GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestLogMPPIGPU:
+    """Log-MPPI GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.log_mppi import LogMPPIController
+
+        params = MPPIParams(K=128, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = LogMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.log_mppi import LogMPPIController
+
+        params = MPPIParams(K=256, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = LogMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+
+# ═══════════════════════════════════════════════════════════════
+# Tsallis-MPPI GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestTsallisMPPIGPU:
+    """Tsallis-MPPI GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.tsallis_mppi import TsallisMPPIController
+
+        params = MPPIParams(K=128, N=30, tsallis_q=1.5, use_gpu=True, gpu_warmup=False)
+        ctrl = TsallisMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.tsallis_mppi import TsallisMPPIController
+
+        params = MPPIParams(K=256, N=30, tsallis_q=1.5, use_gpu=True, gpu_warmup=False)
+        ctrl = TsallisMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+
+# ═══════════════════════════════════════════════════════════════
+# Risk-Aware (CVaR) GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestRiskAwareMPPIGPU:
+    """Risk-Aware MPPI GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.risk_aware_mppi import RiskAwareMPPIController
+
+        params = MPPIParams(K=128, N=30, cvar_alpha=0.5, use_gpu=True, gpu_warmup=False)
+        ctrl = RiskAwareMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.risk_aware_mppi import RiskAwareMPPIController
+
+        params = MPPIParams(K=256, N=30, cvar_alpha=0.5, use_gpu=True, gpu_warmup=False)
+        ctrl = RiskAwareMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+
+# ═══════════════════════════════════════════════════════════════
+# Tube-MPPI GPU (코드 변경 없음 — 검증만)
+# ═══════════════════════════════════════════════════════════════
+
+class TestTubeMPPIGPU:
+    """Tube-MPPI GPU 검증 (super().compute_control()이 GPU 경로 사용)."""
+
+    def test_gpu_tube_enabled(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.tube_mppi import TubeMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            tube_enabled=True,
+        )
+        ctrl = TubeMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("tube_enabled") is True
+
+    def test_gpu_tube_disabled(self, robot_params, state, reference):
+        """tube_enabled=False → GPU Vanilla 경로."""
+        from mpc_controller.controllers.mppi.tube_mppi import TubeMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            tube_enabled=False,
+        )
+        ctrl = TubeMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+
+# ═══════════════════════════════════════════════════════════════
+# Smooth-MPPI GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestSmoothMPPIGPU:
+    """Smooth-MPPI GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.smooth_mppi import SmoothMPPIController
+
+        params = MPPIParams(K=128, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = SmoothMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.smooth_mppi import SmoothMPPIController
+
+        params = MPPIParams(K=256, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = SmoothMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+    def test_has_smooth_info(self, robot_params, state, reference):
+        """Smooth-MPPI 전용 info key 존재."""
+        from mpc_controller.controllers.mppi.smooth_mppi import SmoothMPPIController
+
+        params = MPPIParams(K=128, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = SmoothMPPIController(robot_params, params, seed=42)
+
+        _, info = ctrl.compute_control(state, reference)
+        assert "delta_u_sequence" in info
+        assert "delta_u_norm" in info
+
+
+# ═══════════════════════════════════════════════════════════════
+# Spline-MPPI GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestSplineMPPIGPU:
+    """Spline-MPPI GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.spline_mppi import SplineMPPIController
+
+        params = MPPIParams(K=128, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = SplineMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.spline_mppi import SplineMPPIController
+
+        params = MPPIParams(K=256, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = SplineMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+    def test_has_spline_info(self, robot_params, state, reference):
+        """Spline-MPPI 전용 info key 존재."""
+        from mpc_controller.controllers.mppi.spline_mppi import SplineMPPIController
+
+        params = MPPIParams(K=128, N=30, use_gpu=True, gpu_warmup=False)
+        ctrl = SplineMPPIController(robot_params, params, seed=42)
+
+        _, info = ctrl.compute_control(state, reference)
+        assert "knot_controls" in info
+        assert "num_knots" in info
+
+
+# ═══════════════════════════════════════════════════════════════
+# SVMPC (Stein Variational MPPI) GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestSVMPCGPU:
+    """SVMPC GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.stein_variational_mppi import SteinVariationalMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svgd_num_iterations=2, svgd_step_size=0.1,
+        )
+        ctrl = SteinVariationalMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.stein_variational_mppi import SteinVariationalMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svgd_num_iterations=2, svgd_step_size=0.1,
+        )
+        ctrl = SteinVariationalMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+    def test_diversity_measured(self, robot_params, state, reference):
+        """SVGD diversity 측정 존재."""
+        from mpc_controller.controllers.mppi.stein_variational_mppi import SteinVariationalMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svgd_num_iterations=2,
+        )
+        ctrl = SteinVariationalMPPIController(robot_params, params, seed=42)
+
+        _, info = ctrl.compute_control(state, reference)
+        assert "sample_diversity_before" in info
+        assert "sample_diversity_after" in info
+
+    def test_svgd0_fallback_vanilla(self, robot_params, state, reference):
+        """svgd_num_iterations=0 → Vanilla GPU 경로."""
+        from mpc_controller.controllers.mppi.stein_variational_mppi import SteinVariationalMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svgd_num_iterations=0,
+        )
+        ctrl = SteinVariationalMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        # Vanilla GPU 경로로 실행됨
+        assert info.get("backend") == "gpu"
+
+
+# ═══════════════════════════════════════════════════════════════
+# SVG-MPPI GPU
+# ═══════════════════════════════════════════════════════════════
+
+class TestSVGMPPIGPU:
+    """SVG-MPPI GPU 검증."""
+
+    def test_gpu_compute_control(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.svg_mppi import SVGMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svg_num_guide_particles=8, svg_guide_iterations=2,
+        )
+        ctrl = SVGMPPIController(robot_params, params, seed=42)
+
+        u, info = ctrl.compute_control(state, reference)
+        assert u.shape == (2,)
+        assert info.get("backend") == "gpu"
+
+    def test_convergence(self, robot_params, state, reference):
+        from mpc_controller.controllers.mppi.svg_mppi import SVGMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svg_num_guide_particles=8, svg_guide_iterations=2,
+        )
+        ctrl = SVGMPPIController(robot_params, params, seed=42)
+
+        for _ in range(5):
+            _, info = ctrl.compute_control(state, reference)
+            assert np.isfinite(info["cost"])
+
+    def test_guide_diversity(self, robot_params, state, reference):
+        """SVG-MPPI guide diversity 측정 존재."""
+        from mpc_controller.controllers.mppi.svg_mppi import SVGMPPIController
+
+        params = MPPIParams(
+            K=128, N=30, use_gpu=True, gpu_warmup=False,
+            svg_num_guide_particles=8, svg_guide_iterations=2,
+        )
+        ctrl = SVGMPPIController(robot_params, params, seed=42)
+
+        _, info = ctrl.compute_control(state, reference)
+        assert "guide_diversity_before" in info
+        assert "guide_diversity_after" in info
+        assert "num_guides" in info
+
+
+# ═══════════════════════════════════════════════════════════════
+# GPU Weight 정확도 — GPU vs CPU 수치 비교
+# ═══════════════════════════════════════════════════════════════
+
+class TestGPUWeightAccuracy:
+    """GPU 가중치 == CPU 가중치 (weights-only 변형)."""
+
+    def test_log_gpu_matches_cpu(self):
+        """Log-MPPI: GPU weight == CPU log_sum_exp weight."""
+        from mpc_controller.controllers.mppi.gpu_weights import log_softmax_weights
+        from mpc_controller.controllers.mppi.utils import log_sum_exp
+
+        np.random.seed(42)
+        costs = np.random.rand(200) * 20
+        lambda_ = 5.0
+
+        # CPU (log_mppi.py 로직)
+        log_w = -costs / lambda_
+        log_w -= log_sum_exp(log_w)
+        cpu_w = np.exp(log_w)
+
+        # GPU
+        gpu_w = np.asarray(log_softmax_weights(jnp.array(costs), lambda_))
+
+        np.testing.assert_allclose(gpu_w, cpu_w, rtol=1e-10)
+
+    def test_tsallis_gpu_matches_cpu(self):
+        """Tsallis-MPPI: GPU weight == CPU q_exponential weight."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_tsallis_weights
+        from mpc_controller.controllers.mppi.utils import q_exponential
+
+        np.random.seed(42)
+        costs = np.random.rand(200) * 20
+        lambda_ = 5.0
+        q = 1.5
+
+        # CPU (tsallis_mppi.py 로직)
+        centered = costs - np.min(costs)
+        raw = q_exponential(-centered / lambda_, q)
+        total = np.sum(raw)
+        cpu_w = raw / total if total > 0 else np.ones(200) / 200
+
+        # GPU
+        tsallis_fn = make_tsallis_weights(q)
+        gpu_w = np.asarray(tsallis_fn(jnp.array(costs), lambda_))
+
+        np.testing.assert_allclose(gpu_w, cpu_w, rtol=1e-6)
+
+    def test_cvar_gpu_selects_correct_samples(self):
+        """CVaR: GPU 가 최저비용 샘플을 올바르게 선택."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_cvar_weights
+
+        costs = jnp.arange(20, dtype=jnp.float64)  # [0, 1, ..., 19]
+        alpha = 0.5  # n_keep = 10
+        lambda_ = 5.0
+
+        fn = make_cvar_weights(alpha, 20)
+        w = np.asarray(fn(costs, lambda_))
+
+        # 최저 10개 (0~9)만 non-zero
+        n_nonzero = np.sum(w > 1e-15)
+        assert n_nonzero == 10
+
+        # 상위 10개 (10~19)는 0
+        assert np.sum(w[10:]) < 1e-15

--- a/tests/test_gpu_weights.py
+++ b/tests/test_gpu_weights.py
@@ -1,0 +1,242 @@
+"""GPU 가중치 함수 단위 테스트.
+
+4종 JIT 가중치 함수의 정확도 + 수치 안정성 검증.
+CPU utils 함수와 수치 일치 확인.
+"""
+
+import numpy as np
+import pytest
+
+try:
+    import jax
+    import jax.numpy as jnp
+
+    jax.config.update("jax_enable_x64", True)
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not JAX_AVAILABLE, reason="JAX not installed")
+
+
+@pytest.fixture
+def costs():
+    """테스트 비용 배열 (K=100)."""
+    np.random.seed(42)
+    return jnp.array(np.random.rand(100) * 10)
+
+
+@pytest.fixture
+def lambda_():
+    return 10.0
+
+
+class TestVanillaSoftmax:
+    """Vanilla softmax 가중치 검증."""
+
+    def test_matches_cpu(self, costs, lambda_):
+        """GPU vanilla == CPU softmax_weights (rtol=1e-10)."""
+        from mpc_controller.controllers.mppi.gpu_weights import vanilla_softmax_weights
+        from mpc_controller.controllers.mppi.utils import softmax_weights
+
+        gpu_w = np.asarray(vanilla_softmax_weights(costs, lambda_))
+        cpu_w = softmax_weights(np.asarray(costs), lambda_)
+
+        np.testing.assert_allclose(gpu_w, cpu_w, rtol=1e-10)
+
+    def test_sum_to_one(self, costs, lambda_):
+        """가중치 합 == 1.0."""
+        from mpc_controller.controllers.mppi.gpu_weights import vanilla_softmax_weights
+
+        w = vanilla_softmax_weights(costs, lambda_)
+        np.testing.assert_allclose(float(jnp.sum(w)), 1.0, atol=1e-12)
+
+    def test_non_negative(self, costs, lambda_):
+        """모든 가중치 >= 0."""
+        from mpc_controller.controllers.mppi.gpu_weights import vanilla_softmax_weights
+
+        w = vanilla_softmax_weights(costs, lambda_)
+        assert jnp.all(w >= 0)
+
+
+class TestLogSoftmax:
+    """Log-space softmax 가중치 검증."""
+
+    def test_matches_vanilla(self, costs, lambda_):
+        """Log-softmax == Vanilla softmax (수학적 동일)."""
+        from mpc_controller.controllers.mppi.gpu_weights import (
+            vanilla_softmax_weights,
+            log_softmax_weights,
+        )
+
+        vanilla_w = np.asarray(vanilla_softmax_weights(costs, lambda_))
+        log_w = np.asarray(log_softmax_weights(costs, lambda_))
+
+        np.testing.assert_allclose(log_w, vanilla_w, rtol=1e-10)
+
+    def test_extreme_costs_no_nan(self):
+        """극단 비용 (1e15) → NaN/Inf 없음."""
+        from mpc_controller.controllers.mppi.gpu_weights import log_softmax_weights
+
+        extreme = jnp.array([1e15, 1e14, 1e13, 1.0, 0.0])
+        w = log_softmax_weights(extreme, 10.0)
+
+        assert jnp.all(jnp.isfinite(w))
+        np.testing.assert_allclose(float(jnp.sum(w)), 1.0, atol=1e-10)
+
+    def test_sum_to_one(self, costs, lambda_):
+        """가중치 합 == 1.0."""
+        from mpc_controller.controllers.mppi.gpu_weights import log_softmax_weights
+
+        w = log_softmax_weights(costs, lambda_)
+        np.testing.assert_allclose(float(jnp.sum(w)), 1.0, atol=1e-12)
+
+
+class TestTsallisWeights:
+    """Tsallis q-exponential 가중치 검증."""
+
+    def test_q1_equals_vanilla(self, costs, lambda_):
+        """q=1.0 → Vanilla softmax와 근사 동일.
+
+        q=1.0은 closure에서 1/(1-q) 발산하므로 정확히 같지는 않지만,
+        q→1 극한에서 수렴해야 한다. q=1.001로 근사 검증.
+        """
+        from mpc_controller.controllers.mppi.gpu_weights import (
+            vanilla_softmax_weights,
+            make_tsallis_weights,
+        )
+
+        # q=1.001 (1.0에 매우 가까움)
+        tsallis_fn = make_tsallis_weights(1.001)
+        vanilla_w = np.asarray(vanilla_softmax_weights(costs, lambda_))
+        tsallis_w = np.asarray(tsallis_fn(costs, lambda_))
+
+        # 방향 일치: 최소비용 샘플에 최대 가중치
+        assert np.argmax(tsallis_w) == np.argmax(vanilla_w)
+
+    def test_heavy_tail_q15(self, costs, lambda_):
+        """q=1.5 → heavy-tail (Vanilla보다 더 균등한 분포)."""
+        from mpc_controller.controllers.mppi.gpu_weights import (
+            vanilla_softmax_weights,
+            make_tsallis_weights,
+        )
+
+        vanilla_w = np.asarray(vanilla_softmax_weights(costs, lambda_))
+        heavy_fn = make_tsallis_weights(1.5)
+        heavy_w = np.asarray(heavy_fn(costs, lambda_))
+
+        # heavy-tail: max 가중치가 Vanilla보다 작음 (더 분산)
+        assert np.max(heavy_w) < np.max(vanilla_w) + 0.1
+
+    def test_light_tail_q05(self, costs, lambda_):
+        """q=0.5 → light-tail (Vanilla보다 더 집중된 분포)."""
+        from mpc_controller.controllers.mppi.gpu_weights import (
+            vanilla_softmax_weights,
+            make_tsallis_weights,
+        )
+
+        vanilla_w = np.asarray(vanilla_softmax_weights(costs, lambda_))
+        light_fn = make_tsallis_weights(0.5)
+        light_w = np.asarray(light_fn(costs, lambda_))
+
+        # light-tail: max 가중치가 Vanilla보다 큼 (더 집중)
+        assert np.max(light_w) > np.max(vanilla_w) - 0.1
+
+    def test_sum_to_one(self, costs, lambda_):
+        """가중치 합 == 1.0."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_tsallis_weights
+
+        for q in [0.5, 1.5, 2.0]:
+            fn = make_tsallis_weights(q)
+            w = fn(costs, lambda_)
+            np.testing.assert_allclose(float(jnp.sum(w)), 1.0, atol=1e-6)
+
+    def test_non_negative(self, costs, lambda_):
+        """모든 가중치 >= 0."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_tsallis_weights
+
+        for q in [0.5, 1.5, 2.0]:
+            fn = make_tsallis_weights(q)
+            w = fn(costs, lambda_)
+            assert jnp.all(w >= 0)
+
+
+class TestCVaRWeights:
+    """CVaR 가중치 검증."""
+
+    def test_alpha1_equals_vanilla(self, costs, lambda_):
+        """alpha=1.0 → Vanilla softmax."""
+        from mpc_controller.controllers.mppi.gpu_weights import (
+            vanilla_softmax_weights,
+            make_cvar_weights,
+        )
+
+        cvar_fn = make_cvar_weights(1.0, 100)
+        # alpha >= 1.0이면 vanilla_softmax_weights 자체를 반환
+        assert cvar_fn is vanilla_softmax_weights
+
+    def test_alpha05_half_nonzero(self, costs, lambda_):
+        """alpha=0.5 → K/2개만 non-zero 가중치."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_cvar_weights
+
+        K = costs.shape[0]
+        cvar_fn = make_cvar_weights(0.5, K)
+        w = np.asarray(cvar_fn(costs, lambda_))
+
+        n_nonzero = np.sum(w > 1e-15)
+        expected = max(1, int(np.ceil(0.5 * K)))
+        assert n_nonzero == expected
+
+    def test_sum_to_one(self, costs, lambda_):
+        """가중치 합 == 1.0."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_cvar_weights
+
+        for alpha in [0.3, 0.5, 0.8]:
+            fn = make_cvar_weights(alpha, 100)
+            w = fn(costs, lambda_)
+            np.testing.assert_allclose(float(jnp.sum(w)), 1.0, atol=1e-10)
+
+    def test_selects_lowest_costs(self, lambda_):
+        """CVaR가 최저비용 샘플만 선택하는지 검증."""
+        from mpc_controller.controllers.mppi.gpu_weights import make_cvar_weights
+
+        # 간단한 비용: [0, 1, 2, ..., 9]
+        costs = jnp.arange(10, dtype=jnp.float64)
+        cvar_fn = make_cvar_weights(0.3, 10)  # n_keep = ceil(0.3*10) = 3
+        w = np.asarray(cvar_fn(costs, lambda_))
+
+        # 최저 3개 (0,1,2)만 non-zero
+        assert w[0] > 0
+        assert w[1] > 0
+        assert w[2] > 0
+        assert np.sum(w[3:]) < 1e-15
+
+
+class TestWeightFnRegistry:
+    """get_weight_fn 레지스트리 검증."""
+
+    def test_vanilla(self):
+        from mpc_controller.controllers.mppi.gpu_weights import get_weight_fn, vanilla_softmax_weights
+        assert get_weight_fn("vanilla") is vanilla_softmax_weights
+
+    def test_log(self):
+        from mpc_controller.controllers.mppi.gpu_weights import get_weight_fn, log_softmax_weights
+        assert get_weight_fn("log") is log_softmax_weights
+
+    def test_tsallis(self):
+        from mpc_controller.controllers.mppi.gpu_weights import get_weight_fn
+        fn = get_weight_fn("tsallis", q=1.5)
+        # 호출 가능한 함수인지 확인
+        w = fn(jnp.array([1.0, 2.0, 3.0]), 10.0)
+        assert w.shape == (3,)
+
+    def test_cvar(self):
+        from mpc_controller.controllers.mppi.gpu_weights import get_weight_fn
+        fn = get_weight_fn("cvar", alpha=0.5, K=100)
+        w = fn(jnp.arange(100, dtype=jnp.float64), 10.0)
+        assert w.shape == (100,)
+
+    def test_unknown_raises(self):
+        from mpc_controller.controllers.mppi.gpu_weights import get_weight_fn
+        with pytest.raises(ValueError, match="Unknown"):
+            get_weight_fn("unknown")


### PR DESCRIPTION
## Summary

- Vanilla MPPI GPU 가속(PR #103) 이후, 나머지 8종 MPPI 변형에 GPU 지원 확장
- `GPUMPPIKernel.mppi_step()` 하드코딩 softmax → `weight_fn` Strategy 패턴으로 교체
- 신규 59개 테스트 + 기존 322개 회귀 없음

## 변경 사항

### 신규 파일 (5개)
| 파일 | 설명 |
|------|------|
| `gpu_weights.py` | 4종 JIT 가중치 (vanilla/log/tsallis/cvar) + registry |
| `gpu_svgd.py` | SVGD JIT 커널 (SVMPC/SVG-MPPI 공유) |
| `test_gpu_weights.py` | 가중치 단위 테스트 20개 |
| `test_gpu_svgd.py` | SVGD 커널 테스트 13개 |
| `test_gpu_variants.py` | 8종 통합 테스트 26개 |

### 수정 파일 (11개)
| 파일 | 변경 |
|------|------|
| `gpu_mppi_kernel.py` | weight_fn 주입 + smooth/spline step |
| `gpu_costs.py` | jerk_cost_jit 추가 |
| `gpu_backend.py` | to_numpy writable copy |
| `base_mppi.py` | `_get_gpu_weight_fn()` 가상 메서드 |
| `log_mppi.py` | GPU weight 오버라이드 |
| `tsallis_mppi.py` | GPU weight 오버라이드 (closure) |
| `risk_aware_mppi.py` | GPU weight 오버라이드 (CVaR) |
| `smooth_mppi.py` | GPU Δu space 경로 |
| `spline_mppi.py` | GPU knot space 경로 |
| `stein_variational_mppi.py` | GPU SVGD 루프 |
| `svg_mppi.py` | GPU guide SVGD + follower |

## 아키텍처

```
GPUMPPIKernel
├── mppi_step(weight_fn)       ← Vanilla/Log/Tsallis/CVaR/Tube
├── smooth_mppi_step()         ← Smooth-MPPI (Δu space)
└── spline_mppi_step()         ← Spline-MPPI (knot space)

gpu_svgd.py
├── svgd_step_jit()            ← SVMPC + SVG-MPPI 공유
├── median_bandwidth_jit()
├── compute_diversity_jit()
└── rbf_kernel_jit()
```

## Test plan

- [x] `test_gpu_weights.py` — 20개 통과 (가중치 수치 정확도)
- [x] `test_gpu_svgd.py` — 13개 통과 (SVGD 커널 정확도)
- [x] `test_gpu_variants.py` — 26개 통과 (8종 GPU 통합)
- [x] `test_gpu_mppi.py` — 22개 통과 (기존 Vanilla GPU 회귀)
- [x] 전체 MPPI 테스트 — 322개 통과, 0 실패

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)