### PR TITLE
perf: DIAL-MPPI 실시간 성능 최적화 (Closes #128)

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_dial_non_coaxial_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_dial_non_coaxial_mppi.yaml
@@ -41,12 +41,12 @@ controller_server:
       plugin: "mpc_controller_ros2::DialMPPIControllerPlugin"
       motion_model: "non_coaxial_swerve"
 
-      # Prediction horizon
-      N: 30
+      # Prediction horizon (2.5s — 비홀로노믹 특성상 긴 호라이즌 불필요)
+      N: 25
       dt: 0.1
 
-      # Sampling (어닐링 반복으로 적은 샘플로도 효과적)
-      K: 512
+      # Sampling (어닐링 반복이 다중 패스 정제 → 적은 샘플로도 충분)
+      K: 256
       lambda: 10.0
 
       # Noise parameters — Non-Coaxial: control=[v, omega, delta_dot]
@@ -131,7 +131,7 @@ controller_server:
 
       # ---- DIAL-MPPI 전용 파라미터 ----
       dial_enabled: true
-      dial_n_diffuse: 5
+      dial_n_diffuse: 3
       dial_beta1: 0.8
       dial_beta2: 0.5
       dial_min_noise: 0.01
@@ -139,11 +139,11 @@ controller_server:
       # Shield-DIAL (CBF)
       dial_shield_enabled: false
 
-      # Adaptive-DIAL
-      dial_adaptive_enabled: false
-      dial_adaptive_cost_tol: 0.01
+      # Adaptive-DIAL (실시간 성능 확보: 수렴 시 조기 종료)
+      dial_adaptive_enabled: true
+      dial_adaptive_cost_tol: 0.02
       dial_adaptive_min_iter: 2
-      dial_adaptive_max_iter: 10
+      dial_adaptive_max_iter: 5
 
       # CBF
       cbf_enabled: false

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_dial_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_dial_swerve_mppi.yaml
@@ -13,7 +13,7 @@
 controller_server:
   ros__parameters:
     use_sim_time: true
-    controller_frequency: 20.0
+    controller_frequency: 10.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.001
     min_theta_velocity_threshold: 0.001
@@ -41,12 +41,12 @@ controller_server:
       plugin: "mpc_controller_ros2::DialMPPIControllerPlugin"
       motion_model: "swerve"
 
-      # Prediction horizon
-      N: 40
-      dt: 0.05
+      # Prediction horizon (3.0s → 어닐링이 보상하므로 짧은 호라이즌도 효과적)
+      N: 30
+      dt: 0.1
 
-      # Sampling (어닐링 반복으로 적은 샘플로도 효과적)
-      K: 512
+      # Sampling (어닐링 반복이 다중 패스 정제 → 적은 샘플로도 충분)
+      K: 256
       lambda: 100.0
 
       # Noise parameters (vx, vy, omega)
@@ -122,7 +122,7 @@ controller_server:
 
       # ---- DIAL-MPPI 전용 파라미터 ----
       dial_enabled: true
-      dial_n_diffuse: 5
+      dial_n_diffuse: 3
       dial_beta1: 0.8
       dial_beta2: 0.5
       dial_min_noise: 0.01
@@ -130,11 +130,11 @@ controller_server:
       # Shield-DIAL (CBF)
       dial_shield_enabled: false
 
-      # Adaptive-DIAL
-      dial_adaptive_enabled: false
-      dial_adaptive_cost_tol: 0.01
+      # Adaptive-DIAL (실시간 성능 확보: 수렴 시 조기 종료)
+      dial_adaptive_enabled: true
+      dial_adaptive_cost_tol: 0.02
       dial_adaptive_min_iter: 2
-      dial_adaptive_max_iter: 10
+      dial_adaptive_max_iter: 5
 
       # Non-Coaxial 전용 (swerve에서는 무시 — declare 필수)
       noise_sigma_delta_dot: 0.3

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/dial_mppi_controller_plugin.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/dial_mppi_controller_plugin.hpp
@@ -7,6 +7,17 @@ namespace mpc_controller_ros2
 {
 
 /**
+ * @brief 어닐링 스텝 결과 (마지막 반복의 궤적/가중치를 시각화에 재사용)
+ */
+struct AnnealingResult
+{
+  double mean_cost{0.0};
+  std::vector<Eigen::MatrixXd> trajectories;
+  Eigen::VectorXd weights;
+  Eigen::VectorXd costs;
+};
+
+/**
  * @brief DIAL-MPPI nav2 Controller Plugin
  *
  * Reference: Xue et al. (2024) "DIAL-MPC: Diffusion-Inspired Annealing
@@ -39,22 +50,14 @@ protected:
     const Eigen::MatrixXd& reference_trajectory
   ) override;
 
-  /**
-   * @brief 이중 감쇠 노이즈 스케줄 계산
-   * σ²ᵢₕ = exp(-(N-i)/(β₁·N) - (H-h)/(β₂·H)), clamped ≥ min_noise
-   * @param iteration 현재 어닐링 반복 인덱스 (1-based)
-   * @param n_diffuse 총 어닐링 반복 횟수
-   * @param horizon 예측 호라이즌 길이 H
-   * @return (H,) 벡터: 각 시간 스텝별 노이즈 스케일
-   */
   Eigen::VectorXd computeAnnealingSchedule(
     int iteration, int n_diffuse, int horizon) const;
 
   /**
    * @brief 단일 어닐링 스텝 (샘플링 → 롤아웃 → 가중 업데이트)
-   * @return 이번 반복의 평균 비용
+   * @return AnnealingResult (평균 비용 + 궤적/가중치 — 마지막 반복에서 시각화 재사용)
    */
-  double annealingStep(
+  AnnealingResult annealingStep(
     Eigen::MatrixXd& control_seq,
     const Eigen::VectorXd& current_state,
     const Eigen::MatrixXd& reference_trajectory,

--- a/ros2_ws/src/mpc_controller_ros2/src/dial_mppi_controller_plugin.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/dial_mppi_controller_plugin.cpp
@@ -7,6 +7,10 @@
 // 핵심: MPPI를 단일 스텝 확산 디노이징으로 해석하고, N_diffuse번 반복하며
 //       이중 감쇠 스케줄(반복 β₁ + 호라이즌 β₂)로 노이즈를 줄여 정밀 탐색.
 //
+// 성능 최적화:
+//   - 마지막 어닐링 스텝의 trajectories/weights를 시각화에 재사용
+//   - 추가 K 롤아웃 없이 info 구성 (총 롤아웃 = N_diffuse × K)
+//
 // 확장:
 //   - Shield-DIAL: computeControl 내부에서 CBF Safety Filter 적용
 //   - Adaptive-DIAL: 비용 수렴 시 조기 종료 (dial_adaptive_cost_tol 기반)
@@ -73,17 +77,9 @@ Eigen::VectorXd DialMPPIControllerPlugin::computeAnnealingSchedule(
   double i = static_cast<double>(iteration);
 
   for (int h = 0; h < horizon; ++h) {
-    // σ²ᵢₕ = exp(-(N-i)/(β₁·N) - (H-1-h)/(β₂·H))
-    // 반복 i 증가 → 첫 번째 항 감소(0에 수렴) → σ 증가 방향이지만,
-    // 논문 의도: 초기 반복에서 큰 노이즈, 후기에서 작은 노이즈
-    // -(N-i)/(β₁·N): i=1일 때 -(N-1)/(β₁·N) ≈ -1/β₁ (큰 음수 → 작은 σ²)
-    //                 i=N일 때 0 → σ²=exp(호라이즌 항)
-    // 실제 구현: 반복이 진행될수록 노이즈 감소해야 하므로 부호 반전
     double iter_decay = -(static_cast<double>(n_diffuse) - i) / (beta1 * N + 1e-8);
     double horizon_decay = -(H - 1.0 - static_cast<double>(h)) / (beta2 * H + 1e-8);
     double sigma = std::exp(iter_decay + horizon_decay);
-
-    // 최소 노이즈 하한 클램프
     schedule(h) = std::max(sigma, min_noise);
   }
 
@@ -91,10 +87,10 @@ Eigen::VectorXd DialMPPIControllerPlugin::computeAnnealingSchedule(
 }
 
 // =============================================================================
-// 단일 어닐링 스텝
+// 단일 어닐링 스텝 — AnnealingResult 반환 (시각화 재사용)
 // =============================================================================
 
-double DialMPPIControllerPlugin::annealingStep(
+AnnealingResult DialMPPIControllerPlugin::annealingStep(
   Eigen::MatrixXd& control_seq,
   const Eigen::VectorXd& current_state,
   const Eigen::MatrixXd& reference_trajectory,
@@ -104,19 +100,17 @@ double DialMPPIControllerPlugin::annealingStep(
   int N = params_.N;
   int K = params_.K;
   int nu = dynamics_->model().controlDim();
-  (void)iteration;  // 현재 미사용, 향후 로깅용
+  (void)iteration;
 
-  // 2b: 단위 노이즈 샘플링
+  // 2b: 단위 노이즈 샘플링 + 스케줄 적용
   auto base_noise = sampler_->sample(K, N, nu);
-
-  // 2b': 노이즈 스케줄 적용 (시간 축별 다른 스케일)
   for (int k = 0; k < K; ++k) {
     for (int h = 0; h < N; ++h) {
       base_noise[k].row(h) *= noise_schedule(h);
     }
   }
 
-  // 2c: 섭동 시퀀스 구성 (Exploitation/Exploration 분할)
+  // 2c: 섭동 시퀀스 구성
   std::vector<Eigen::MatrixXd> perturbed_controls;
   perturbed_controls.reserve(K);
   int K_exploit = static_cast<int>((1.0 - params_.exploration_ratio) * K);
@@ -139,7 +133,7 @@ double DialMPPIControllerPlugin::annealingStep(
   Eigen::VectorXd costs = cost_function_->compute(
     trajectories, perturbed_controls, reference_trajectory);
 
-  // 2e: IT 정규화 (선택사항)
+  // 2e: IT 정규화
   if (params_.it_alpha < 1.0) {
     Eigen::VectorXd sigma_inv = params_.noise_sigma.cwiseInverse().cwiseAbs2();
     for (int k = 0; k < K; ++k) {
@@ -153,7 +147,7 @@ double DialMPPIControllerPlugin::annealingStep(
     }
   }
 
-  // 2f: 가중치 계산 (기존 WeightComputation 전략 재사용)
+  // 2f: 가중치 계산
   double current_lambda = params_.lambda;
   if (params_.adaptive_temperature && adaptive_temp_) {
     Eigen::VectorXd temp_weights = weight_computation_->compute(costs, current_lambda);
@@ -162,7 +156,7 @@ double DialMPPIControllerPlugin::annealingStep(
   }
   Eigen::VectorXd weights = weight_computation_->compute(costs, current_lambda);
 
-  // 2g: 가중 업데이트 (noise 기반)
+  // 2g: 가중 업데이트
   Eigen::MatrixXd weighted_noise = Eigen::MatrixXd::Zero(N, nu);
   for (int k = 0; k < K; ++k) {
     weighted_noise += weights(k) * base_noise[k];
@@ -170,12 +164,17 @@ double DialMPPIControllerPlugin::annealingStep(
   control_seq += weighted_noise;
   control_seq = dynamics_->clipControls(control_seq);
 
-  // 평균 비용 반환 (Adaptive-DIAL 조기 종료용)
-  return costs.mean();
+  // 결과 반환 (궤적/가중치를 시각화에 재사용)
+  AnnealingResult result;
+  result.mean_cost = costs.mean();
+  result.trajectories = std::move(trajectories);
+  result.weights = std::move(weights);
+  result.costs = std::move(costs);
+  return result;
 }
 
 // =============================================================================
-// computeControl — DIAL 어닐링 파이프라인
+// computeControl — DIAL 어닐링 파이프라인 (최적화: 추가 롤아웃 없음)
 // =============================================================================
 
 std::pair<Eigen::VectorXd, MPPIInfo> DialMPPIControllerPlugin::computeControl(
@@ -189,7 +188,6 @@ std::pair<Eigen::VectorXd, MPPIInfo> DialMPPIControllerPlugin::computeControl(
 
   int N = params_.N;
   int K = params_.K;
-  int nu = dynamics_->model().controlDim();
   int nx = dynamics_->model().stateDim();
 
   // ──── STEP 1: Warm-start (shift control sequence) ────
@@ -204,99 +202,63 @@ std::pair<Eigen::VectorXd, MPPIInfo> DialMPPIControllerPlugin::computeControl(
   double prev_cost = std::numeric_limits<double>::infinity();
   int actual_iterations = 0;
 
-  Eigen::VectorXd last_weights;
-  double last_mean_cost = 0.0;
+  AnnealingResult last_result;
 
   for (int i = 1; i <= max_iter; ++i) {
-    // 2a: 이중 감쇠 노이즈 스케줄
     Eigen::VectorXd noise_schedule = computeAnnealingSchedule(i, max_iter, N);
 
-    // 2b-2g: 단일 어닐링 스텝
-    double mean_cost = annealingStep(
+    last_result = annealingStep(
       control_sequence_, current_state, reference_trajectory,
       noise_schedule, i);
 
     actual_iterations = i;
-    last_mean_cost = mean_cost;
 
-    // 2h: Adaptive-DIAL 조기 종료
+    // Adaptive-DIAL 조기 종료
     if (params_.dial_adaptive_enabled && i >= params_.dial_adaptive_min_iter) {
-      double improvement = (prev_cost - mean_cost) / (std::abs(prev_cost) + 1e-8);
+      double improvement = (prev_cost - last_result.mean_cost) /
+        (std::abs(prev_cost) + 1e-8);
       if (improvement < params_.dial_adaptive_cost_tol) {
         break;
       }
     }
-    prev_cost = mean_cost;
+    prev_cost = last_result.mean_cost;
   }
 
   // ──── STEP 3: 최적 제어 추출 ────
   Eigen::VectorXd u_opt = control_sequence_.row(0).transpose();
 
-  // ──── STEP 4: Shield-DIAL (CBF 안전 필터) ────
-  // 주의: base의 computeVelocityCommands에서도 CBF가 적용되지만,
-  //       Shield-DIAL은 DIAL 전용 파라미터로 분리 제어됨
-  CBFFilterInfo cbf_info;
+  // ──── STEP 4: Shield-DIAL (CBF) ────
   bool cbf_applied = false;
   if (params_.dial_shield_enabled && params_.cbf_enabled &&
       params_.cbf_use_safety_filter) {
-    // cbf_safety_filter_는 base의 private 멤버이므로 여기서는
-    // base의 CBF 파이프라인에 위임 (computeVelocityCommands에서 적용)
-    // 따라서 Shield-DIAL은 base의 cbf_enabled를 활용
     cbf_applied = true;
   }
 
-  // ──── STEP 5: 최종 롤아웃 (info 구성용) ────
-  std::vector<Eigen::MatrixXd> final_perturbed;
-  final_perturbed.push_back(control_sequence_);
-  auto final_traj = dynamics_->rolloutBatch(
-    current_state, final_perturbed, params_.dt);
-
-  // ──── STEP 6: MPPIInfo 구성 ────
-  // 마지막 반복의 가중치/궤적으로 최소한의 info 구성
-  auto noise_samples_final = sampler_->sample(K, N, nu);
-  Eigen::VectorXd final_noise_schedule = computeAnnealingSchedule(
-    actual_iterations, max_iter, N);
-
-  std::vector<Eigen::MatrixXd> viz_perturbed;
-  viz_perturbed.reserve(K);
-  for (int k = 0; k < K; ++k) {
-    Eigen::MatrixXd perturbed = control_sequence_;
-    for (int h = 0; h < N; ++h) {
-      perturbed.row(h) += final_noise_schedule(h) * noise_samples_final[k].row(h);
-    }
-    perturbed = dynamics_->clipControls(perturbed);
-    viz_perturbed.push_back(perturbed);
-  }
-
-  auto viz_trajectories = dynamics_->rolloutBatch(
-    current_state, viz_perturbed, params_.dt);
-
-  Eigen::VectorXd viz_costs = cost_function_->compute(
-    viz_trajectories, viz_perturbed, reference_trajectory);
-
-  Eigen::VectorXd weights = weight_computation_->compute(viz_costs, params_.lambda);
+  // ──── STEP 5: MPPIInfo 구성 (마지막 반복 결과 재사용 — 추가 롤아웃 없음) ────
+  const auto& trajectories = last_result.trajectories;
+  const auto& weights = last_result.weights;
+  const auto& costs = last_result.costs;
 
   // Weighted average trajectory
   Eigen::MatrixXd weighted_traj = Eigen::MatrixXd::Zero(N + 1, nx);
   for (int k = 0; k < K; ++k) {
-    weighted_traj += weights(k) * viz_trajectories[k];
+    weighted_traj += weights(k) * trajectories[k];
   }
 
   // Best sample
   int best_idx;
-  double min_cost = viz_costs.minCoeff(&best_idx);
+  double min_cost = costs.minCoeff(&best_idx);
   double ess = computeESS(weights);
 
   MPPIInfo info;
-  info.sample_trajectories = viz_trajectories;
+  info.sample_trajectories = trajectories;
   info.sample_weights = weights;
-  info.best_trajectory = (final_traj.empty()) ?
-    viz_trajectories[best_idx] : final_traj[0];
+  info.best_trajectory = trajectories[best_idx];
   info.weighted_avg_trajectory = weighted_traj;
   info.temperature = (params_.adaptive_temperature && adaptive_temp_) ?
     adaptive_temp_->getLambda() : params_.lambda;
   info.ess = ess;
-  info.costs = viz_costs;
+  info.costs = costs;
 
   info.colored_noise_used = params_.colored_noise;
   info.adaptive_temp_used = params_.adaptive_temperature;
@@ -309,7 +271,7 @@ std::pair<Eigen::VectorXd, MPPIInfo> DialMPPIControllerPlugin::computeControl(
   RCLCPP_DEBUG(
     node_->get_logger(),
     "DIAL-MPPI: iter=%d/%d, min_cost=%.4f, mean_cost=%.4f, ESS=%.1f/%d",
-    actual_iterations, max_iter, min_cost, last_mean_cost, ess, K);
+    actual_iterations, max_iter, min_cost, last_result.mean_cost, ess, K);
 
   return {u_opt, info};
 }

--- a/ros2_ws/src/mpc_controller_ros2/test/unit/test_dial_mppi.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/test/unit/test_dial_mppi.cpp
@@ -59,7 +59,7 @@ public:
     return computeAnnealingSchedule(iteration, n_diffuse, horizon);
   }
 
-  double callAnnealingStep(
+  AnnealingResult callAnnealingStep(
     Eigen::MatrixXd& control_seq,
     const Eigen::VectorXd& state,
     const Eigen::MatrixXd& ref_traj,
@@ -201,7 +201,8 @@ TEST_F(DialMPPITest, SingleIterationEqualsScaledMPPI)
   // annealingStep 1회 실행
   Eigen::MatrixXd cs = Eigen::MatrixXd::Zero(params_.N, 2);
   auto noise_schedule = accessor.callComputeAnnealingSchedule(1, 1, params_.N);
-  double cost = accessor.callAnnealingStep(cs, state_, ref_traj_, noise_schedule, 1);
+  auto result = accessor.callAnnealingStep(cs, state_, ref_traj_, noise_schedule, 1);
+  double cost = result.mean_cost;
 
   // 비용이 유한하고, 제어 시퀀스가 변경됨
   EXPECT_TRUE(std::isfinite(cost));
@@ -232,9 +233,9 @@ TEST_F(DialMPPITest, MultipleIterationsReduceCost)
   std::vector<double> costs;
   for (int i = 1; i <= N_diff; ++i) {
     auto noise_schedule = accessor.callComputeAnnealingSchedule(i, N_diff, params_.N);
-    double mean_cost = accessor.callAnnealingStep(
+    auto ar = accessor.callAnnealingStep(
       cs, state_, ref_traj_, noise_schedule, i);
-    costs.push_back(mean_cost);
+    costs.push_back(ar.mean_cost);
   }
 
   // 최소한 마지막 반복 비용이 첫 번째보다 작거나 같아야 함 (단조 감소는 보장 안됨)
@@ -265,7 +266,8 @@ TEST_F(DialMPPITest, ControlSequenceConverges)
   for (int i = 1; i <= N_diff; ++i) {
     Eigen::MatrixXd cs_prev = cs;
     auto noise_schedule = accessor.callComputeAnnealingSchedule(i, N_diff, params_.N);
-    accessor.callAnnealingStep(cs, state_, ref_traj_, noise_schedule, i);
+    auto ar_c = accessor.callAnnealingStep(cs, state_, ref_traj_, noise_schedule, i);
+    (void)ar_c;
     double delta = (cs - cs_prev).norm();
     deltas.push_back(delta);
   }
@@ -300,7 +302,8 @@ TEST_F(DialMPPITest, IterationCountMatchesParam)
   for (int i = 1; i <= params_.dial_n_diffuse; ++i) {
     auto noise_schedule = accessor.callComputeAnnealingSchedule(
       i, params_.dial_n_diffuse, params_.N);
-    accessor.callAnnealingStep(cs, state_, ref_traj_, noise_schedule, i);
+    auto ar_i = accessor.callAnnealingStep(cs, state_, ref_traj_, noise_schedule, i);
+    (void)ar_i;
     ++count;
   }
   EXPECT_EQ(count, 7);
@@ -338,8 +341,9 @@ TEST_F(DialMPPITest, EarlyTermination)
   for (int i = 1; i <= params_.dial_adaptive_max_iter; ++i) {
     auto noise_schedule = accessor.callComputeAnnealingSchedule(
       i, params_.dial_adaptive_max_iter, params_.N);
-    double mean_cost = accessor.callAnnealingStep(
+    auto ar_a = accessor.callAnnealingStep(
       cs, state_, ref_traj_, noise_schedule, i);
+    double mean_cost = ar_a.mean_cost;
     actual_iter = i;
 
     if (i >= params_.dial_adaptive_min_iter) {
@@ -383,8 +387,9 @@ TEST_F(DialMPPITest, MinIterationRespected)
   for (int i = 1; i <= params_.dial_adaptive_max_iter; ++i) {
     auto noise_schedule = accessor.callComputeAnnealingSchedule(
       i, params_.dial_adaptive_max_iter, params_.N);
-    double mean_cost = accessor.callAnnealingStep(
+    auto ar_a = accessor.callAnnealingStep(
       cs, state_, ref_traj_, noise_schedule, i);
+    double mean_cost = ar_a.mean_cost;
     actual_iter = i;
 
     if (i >= params_.dial_adaptive_min_iter) {
@@ -428,8 +433,9 @@ TEST_F(DialMPPITest, MaxIterationCap)
   for (int i = 1; i <= params_.dial_adaptive_max_iter; ++i) {
     auto noise_schedule = accessor.callComputeAnnealingSchedule(
       i, params_.dial_adaptive_max_iter, params_.N);
-    double mean_cost = accessor.callAnnealingStep(
+    auto ar_a = accessor.callAnnealingStep(
       cs, state_, ref_traj_, noise_schedule, i);
+    double mean_cost = ar_a.mean_cost;
     actual_iter = i;
 
     if (i >= params_.dial_adaptive_min_iter) {
@@ -577,8 +583,9 @@ TEST_F(DialMPPITest, WorksWithSwerveModel)
   auto noise_schedule = accessor.callComputeAnnealingSchedule(
     1, swerve_params.dial_n_diffuse, swerve_params.N);
 
-  double mean_cost = accessor.callAnnealingStep(
+  auto ar_s = accessor.callAnnealingStep(
     cs, state_, ref_traj_, noise_schedule, 1);
+  double mean_cost = ar_s.mean_cost;
 
   EXPECT_TRUE(std::isfinite(mean_cost));
   EXPECT_EQ(cs.cols(), 3);


### PR DESCRIPTION
## Summary

- DIAL-MPPI `computeControl`에서 불필요한 시각화 롤아웃 제거 (AnnealingResult 구조체 도입)
- Swerve/NonCoaxial YAML 파라미터 튜닝으로 실시간 성능 확보
- 총 롤아웃 ~4× 감소 (Swerve: 102,400→23,040, NonCoaxial: 76,800→19,200)

## Changes

### AnnealingResult 리팩터링
- `annealingStep` 반환값을 `double` → `AnnealingResult` 구조체로 변경
- 마지막 어닐링 반복의 trajectories/weights/costs를 MPPIInfo 구성에 재사용
- **추가 K 롤아웃 완전 제거** (총 롤아웃 = N_diffuse × K)

### Swerve/NonCoaxial YAML 성능 튜닝

| 파라미터 | Swerve (전→후) | NonCoaxial (전→후) |
|---------|----------------|-------------------|
| freq | 20Hz → 10Hz | 10Hz (유지) |
| K | 512 → 256 | 512 → 256 |
| N | 40 → 30 | 30 → 25 |
| N_diffuse | 5 → 3 | 5 → 3 |
| Adaptive | off → on (min=2,max=5) | off → on (min=2,max=5) |

## Test plan

- [x] 17/17 DIAL-MPPI gtest 통과
- [x] 14/14 전체 gtest 회귀 확인 (256개 테스트)
- [ ] `controller:=dial_swerve` 멈칫거림 해소 확인
- [ ] `controller:=dial_non_coaxial` 주행 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)