### PR TITLE
feat: Ackermann MotionModel C++ (Bicycle model, Closes #137)

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
+++ b/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(mppi_controller_plugin SHARED
   src/diff_drive_model.cpp
   src/swerve_drive_model.cpp
   src/non_coaxial_swerve_model.cpp
+  src/ackermann_model.cpp
   src/motion_model_factory.cpp
   src/barrier_function.cpp
   src/cbf_safety_filter.cpp

--- a/ros2_ws/src/mpc_controller_ros2/config/ackermann_steering_controller.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/ackermann_steering_controller.yaml
@@ -1,0 +1,19 @@
+# ============================================================
+# Ackermann Steering Controller (ros2_control)
+# ============================================================
+ackermann_steering_controller:
+  ros__parameters:
+    wheelbase: 0.5
+    traction_track_width: 0.4
+    steering_track_width: 0.4
+    traction_wheels_radius: 0.1
+    traction_joints_names:
+      - rear_left_wheel_joint
+      - rear_right_wheel_joint
+    steering_joints_names:
+      - front_left_steer_joint
+      - front_right_steer_joint
+    enable_odom_tf: true
+    odom_frame_id: odom
+    base_frame_id: base_link
+    publish_rate: 50.0

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_ackermann_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_ackermann_mppi.yaml
@@ -1,0 +1,112 @@
+# ============================================================
+# nav2 파라미터 - Ackermann MPPI (mpc_controller_ros2)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=ackermann
+#
+# Bicycle model: θ̇ = v·tan(δ)/L, State=[x,y,θ,δ], Control=[v,δ̇]
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    use_sim_time: true
+    controller_frequency: 10.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.001
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.5
+    transform_tolerance: 1.0
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["goal_checker"]
+    controller_plugins: ["FollowPath"]
+
+    # Progress checker
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.3
+      movement_time_allowance: 30.0
+
+    # Goal checker
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.25
+      yaw_goal_tolerance: 0.25
+      stateful: true
+
+    # ---- Ackermann MPPI Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::MPPIControllerPlugin"
+      motion_model: "ackermann"
+
+      # Prediction horizon
+      N: 30
+      dt: 0.1
+
+      # Sampling
+      K: 512
+      lambda: 10.0
+
+      # Noise parameters [v, delta_dot]
+      noise_sigma_v: 0.3
+      noise_sigma_omega: 0.5
+
+      # Control limits
+      v_max: 0.5
+      v_min: 0.0
+      omega_max: 1.0
+      omega_min: -1.0
+
+      # Ackermann 전용
+      wheelbase: 0.5
+      max_steering_rate: 2.0
+      max_steering_angle: 0.7854   # ~45deg
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 1.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 2.0
+
+      # Control effort weights (R) [v, delta_dot]
+      R_v: 0.5
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 1.0
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 100.0
+      safety_distance: 0.5
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 10.0
+      prefer_forward_linear_ratio: 0.5
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+      adaptation_rate: 0.1
+      lambda_min: 0.1
+      lambda_max: 100.0
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/ackermann_model.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/ackermann_model.hpp
@@ -1,0 +1,73 @@
+#ifndef MPC_CONTROLLER_ROS2__ACKERMANN_MODEL_HPP_
+#define MPC_CONTROLLER_ROS2__ACKERMANN_MODEL_HPP_
+
+#include "mpc_controller_ros2/motion_model.hpp"
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief Ackermann (Bicycle model) 동역학 모델
+ *
+ * 전륜 조향 차량의 Bicycle model 근사.
+ * θ̇ = v·tan(δ)/L 구속 조건으로 NonCoaxialSwerve(omega 독립)와 구분.
+ *
+ * State:   [x, y, theta, delta]     (nx=4)
+ * Control: [v, delta_dot]           (nu=2)
+ *
+ * 연속 동역학:
+ *   x_dot     = v * cos(theta)
+ *   y_dot     = v * sin(theta)
+ *   theta_dot = v * tan(delta) / wheelbase   ← Ackermann 핵심
+ *   delta_dot = delta_dot (제어 입력)
+ */
+class AckermannModel : public MotionModel
+{
+public:
+  AckermannModel(
+    double v_min, double v_max, double max_steering_rate,
+    double max_steering_angle, double wheelbase);
+
+  int stateDim() const override { return 4; }
+  int controlDim() const override { return 2; }
+  bool isHolonomic() const override { return false; }
+  std::string name() const override { return "ackermann"; }
+
+  Eigen::MatrixXd dynamicsBatch(
+    const Eigen::MatrixXd& states,
+    const Eigen::MatrixXd& controls) const override;
+
+  Eigen::MatrixXd clipControls(
+    const Eigen::MatrixXd& controls) const override;
+
+  void normalizeStates(Eigen::MatrixXd& states) const override;
+
+  geometry_msgs::msg::Twist controlToTwist(
+    const Eigen::VectorXd& control) const override;
+
+  Eigen::VectorXd twistToControl(
+    const geometry_msgs::msg::Twist& twist) const override;
+
+  std::vector<int> angleIndices() const override { return {2}; }
+
+  // delta clamp 추가된 RK4 propagation
+  Eigen::MatrixXd propagateBatch(
+    const Eigen::MatrixXd& states,
+    const Eigen::MatrixXd& controls,
+    double dt) const override;
+
+  // controlToTwist용 last_delta_ 추적 (플러그인에서 갱신)
+  void setLastDelta(double delta) { last_delta_ = delta; }
+  double getLastDelta() const { return last_delta_; }
+
+  double wheelbase() const { return wheelbase_; }
+
+private:
+  double v_min_, v_max_, max_steering_rate_, max_steering_angle_;
+  double wheelbase_;
+  double last_delta_{0.0};
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__ACKERMANN_MODEL_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
@@ -169,9 +169,10 @@ struct MPPIParams
   // ============================================================================
   // CBF (Control Barrier Function) 안전성 보장 파라미터
   // ============================================================================
-  // Non-Coaxial Swerve 전용 파라미터
+  // Non-Coaxial Swerve / Ackermann 공통 파라미터
   double max_steering_rate{2.0};            // 최대 스티어링 각속도 (rad/s)
   double max_steering_angle{M_PI / 2.0};    // 최대 스티어링 각도 (rad)
+  double wheelbase{0.5};                    // Ackermann 축간 거리 (m)
 
   bool cbf_enabled{false};                 // CBF 활성화 여부
   double cbf_gamma{1.0};                   // CBF class-K 함수 계수
@@ -190,7 +191,7 @@ struct MPPIParams
   // ============================================================================
   // Motion Model 선택
   // ============================================================================
-  std::string motion_model{"diff_drive"};  // "diff_drive", "swerve", "non_coaxial_swerve"
+  std::string motion_model{"diff_drive"};  // "diff_drive", "swerve", "non_coaxial_swerve", "ackermann"
 
   // ============================================================================
   // Costmap 기반 장애물 비용 파라미터

--- a/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
+++ b/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
@@ -60,6 +60,7 @@ nav2 노드는 non-composition 모드로 실행하며, bond_timeout=0.0으로 bo
     controller:=swerve       → Swerve Drive MPPI (motion_model=swerve)
     controller:=non_coaxial  → Non-Coaxial Swerve MPPI (motion_model=non_coaxial_swerve)
     controller:=non_coaxial_60deg → Non-Coaxial Swerve MPPI 60° (max_steering_angle=π/3)
+    controller:=ackermann    → Ackermann MPPI (motion_model=ackermann, bicycle model)
     controller:=nav2         → nav2 기본 MPPI (nav2_mppi_controller::MPPIController)
     controller:=stress_test  → Stress Test MPPI (고속 v_max=1.5 + CBF + 동적 장애물)
 """
@@ -127,6 +128,8 @@ def launch_setup(context, *args, **kwargs):
                              'DIAL-MPPI Non-Coaxial (motion_model=non_coaxial_swerve)'),
         'stress_test': ('nav2_params_stress_test.yaml',
                         'Stress Test MPPI (고속 + CBF + 동적 장애물)'),
+        'ackermann': ('nav2_params_ackermann_mppi.yaml',
+                      'Ackermann MPPI (motion_model=ackermann, bicycle model)'),
     }
     if controller_type in controller_map:
         params_name, controller_label = controller_map[controller_type]
@@ -142,8 +145,17 @@ def launch_setup(context, *args, **kwargs):
         'dial_swerve', 'dial_non_coaxial',
     ]
 
+    # Ackermann 판별
+    is_ackermann = controller_type in ['ackermann']
+
     # URDF / ros2_control config / nav2 공통 파라미터 분기
-    if is_swerve:
+    if is_ackermann:
+        urdf_file = os.path.join(pkg_dir, 'urdf', 'ackermann_robot.urdf')
+        controller_config = os.path.join(pkg_dir, 'config', 'ackermann_steering_controller.yaml')
+        nav2_params_file = os.path.join(pkg_dir, 'config', 'nav2_params.yaml')
+        robot_name = 'ackermann_robot'
+        spawn_z = '0.15'
+    elif is_swerve:
         urdf_file = os.path.join(pkg_dir, 'urdf', 'swerve_robot.urdf')
         controller_config = os.path.join(pkg_dir, 'config', 'swerve_drive_controller.yaml')
         nav2_params_file = os.path.join(pkg_dir, 'config', 'nav2_params_swerve.yaml')
@@ -226,7 +238,7 @@ def launch_setup(context, *args, **kwargs):
         '/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock',
         '/scan@sensor_msgs/msg/LaserScan[gz.msgs.LaserScan',
     ]
-    if is_swerve:
+    if is_swerve or is_ackermann:
         # Gazebo ground truth odom → ROS2 (OdometryPublisher 플러그인)
         bridge_args.append(
             f'/model/{robot_name}/odometry@nav_msgs/msg/Odometry[gz.msgs.Odometry'
@@ -302,7 +314,13 @@ def launch_setup(context, *args, **kwargs):
         output='screen',
     )
 
-    if is_swerve:
+    if is_ackermann:
+        ackermann_spawner = ExecuteProcess(
+            cmd=_make_spawner_cmd('ackermann_steering_controller',
+                                  f'--param-file {controller_config}'),
+            output='screen',
+        )
+    elif is_swerve:
         steer_spawner = ExecuteProcess(
             cmd=_make_spawner_cmd('steer_position_controller',
                                   f'--param-file {controller_config}'),
@@ -321,7 +339,47 @@ def launch_setup(context, *args, **kwargs):
         )
 
     # ========== 6. cmd_vel relay ==========
-    if is_swerve:
+    if is_ackermann:
+        # Ackermann: Twist → TwistStamped relay for ackermann_steering_controller/reference
+        ack_twist_to_stamped_cmd = '''
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from geometry_msgs.msg import Twist, TwistStamped
+
+class TwistStamper(Node):
+    def __init__(self):
+        super().__init__("ackermann_twist_stamper")
+        qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+        self.pub = self.create_publisher(TwistStamped, "/ackermann_steering_controller/reference", qos)
+        self.sub = self.create_subscription(Twist, "/cmd_vel_nav", self.cb, 10)
+    def cb(self, msg):
+        out = TwistStamped()
+        out.header.stamp = self.get_clock().now().to_msg()
+        out.header.frame_id = "base_link"
+        out.twist = msg
+        self.pub.publish(out)
+
+rclpy.init()
+rclpy.spin(TwistStamper())
+'''
+        cmd_vel_relay = ExecuteProcess(
+            cmd=['python3', '-c', ack_twist_to_stamped_cmd],
+            output='screen'
+        )
+
+        # Gazebo ground truth odom → odom→base_link TF broadcast
+        odom_to_tf = Node(
+            package='mpc_controller_ros2',
+            executable='odom_to_tf.py',
+            name='odom_to_tf',
+            output='screen',
+            parameters=[{'use_sim_time': True}],
+            remappings=[
+                ('odom', f'/model/{robot_name}/odometry'),
+            ],
+        )
+    elif is_swerve:
         # SwerveKinematicsNode: IK 전용 (Gazebo ground truth odom 사용 시 FK/odom/TF 비활성화)
         cmd_vel_relay = Node(
             package='mpc_controller_ros2',
@@ -526,13 +584,30 @@ rclpy.spin(TwistStamper())
                     jsb_spawner,
                     # cmd_vel relay는 컨트롤러와 독립 — 병렬 시작
                     cmd_vel_relay,
-                    *([odom_to_tf] if is_swerve else []),
+                    *([odom_to_tf] if (is_swerve or is_ackermann) else []),
                 ],
             )
         ),
     ]
 
-    if is_swerve:
+    if is_ackermann:
+        nodes.extend([
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=jsb_spawner,
+                    on_exit=[ackermann_spawner],
+                )
+            ),
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=ackermann_spawner,
+                    on_exit=[
+                        LogInfo(msg='Ackermann steering controller activated'),
+                    ],
+                )
+            ),
+        ])
+    elif is_swerve:
         nodes.extend([
             RegisterEventHandler(
                 OnProcessExit(
@@ -632,7 +707,7 @@ def generate_launch_description():
             default_value='custom',
             description='MPPI controller type: "custom", "log", "tsallis", "risk_aware", '
                         '"svmpc", "smooth", "spline", "svg", "biased", "swerve", '
-                        '"non_coaxial", "non_coaxial_60deg", "stress_test", or "nav2"'
+                        '"non_coaxial", "non_coaxial_60deg", "ackermann", "stress_test", or "nav2"'
         ),
         DeclareLaunchArgument(
             'headless',

--- a/ros2_ws/src/mpc_controller_ros2/src/ackermann_model.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/ackermann_model.cpp
@@ -1,0 +1,98 @@
+#include "mpc_controller_ros2/ackermann_model.hpp"
+#include "mpc_controller_ros2/utils.hpp"
+
+namespace mpc_controller_ros2
+{
+
+AckermannModel::AckermannModel(
+  double v_min, double v_max, double max_steering_rate,
+  double max_steering_angle, double wheelbase)
+: v_min_(v_min), v_max_(v_max),
+  max_steering_rate_(max_steering_rate),
+  max_steering_angle_(max_steering_angle),
+  wheelbase_(wheelbase)
+{
+}
+
+Eigen::MatrixXd AckermannModel::dynamicsBatch(
+  const Eigen::MatrixXd& states,
+  const Eigen::MatrixXd& controls) const
+{
+  int M = states.rows();
+  Eigen::MatrixXd state_dot(M, 4);
+
+  Eigen::VectorXd theta = states.col(2);
+  Eigen::VectorXd delta = states.col(3);
+  Eigen::VectorXd v = controls.col(0);
+  Eigen::VectorXd delta_dot = controls.col(1);
+
+  Eigen::ArrayXd cos_theta = theta.array().cos();
+  Eigen::ArrayXd sin_theta = theta.array().sin();
+  Eigen::ArrayXd tan_delta = delta.array().tan();
+
+  // Bicycle model dynamics
+  state_dot.col(0) = v.array() * cos_theta;                    // x_dot
+  state_dot.col(1) = v.array() * sin_theta;                    // y_dot
+  state_dot.col(2) = v.array() * tan_delta / wheelbase_;       // theta_dot = v*tan(δ)/L
+  state_dot.col(3) = delta_dot;                                 // delta_dot
+
+  return state_dot;
+}
+
+Eigen::MatrixXd AckermannModel::clipControls(
+  const Eigen::MatrixXd& controls) const
+{
+  Eigen::MatrixXd clipped = controls;
+  clipped.col(0) = clipped.col(0).cwiseMax(v_min_).cwiseMin(v_max_);
+  clipped.col(1) = clipped.col(1).cwiseMax(-max_steering_rate_).cwiseMin(max_steering_rate_);
+  return clipped;
+}
+
+void AckermannModel::normalizeStates(Eigen::MatrixXd& states) const
+{
+  // theta 각도 정규화
+  states.col(2) = normalizeAngleBatch(states.col(2));
+  // delta (steering angle) clamp to limits
+  states.col(3) = states.col(3).cwiseMax(-max_steering_angle_).cwiseMin(max_steering_angle_);
+}
+
+Eigen::MatrixXd AckermannModel::propagateBatch(
+  const Eigen::MatrixXd& states,
+  const Eigen::MatrixXd& controls,
+  double dt) const
+{
+  // RK4 integration
+  Eigen::MatrixXd k1 = dynamicsBatch(states, controls);
+  Eigen::MatrixXd k2 = dynamicsBatch(states + dt / 2.0 * k1, controls);
+  Eigen::MatrixXd k3 = dynamicsBatch(states + dt / 2.0 * k2, controls);
+  Eigen::MatrixXd k4 = dynamicsBatch(states + dt * k3, controls);
+
+  Eigen::MatrixXd states_next = states + dt / 6.0 * (k1 + 2.0 * k2 + 2.0 * k3 + k4);
+
+  // Normalize (angle wrapping + delta clamp)
+  normalizeStates(states_next);
+
+  return states_next;
+}
+
+geometry_msgs::msg::Twist AckermannModel::controlToTwist(
+  const Eigen::VectorXd& control) const
+{
+  geometry_msgs::msg::Twist twist;
+  double v = control(0);
+  // Ackermann: linear.x=v, angular.z = v*tan(δ)/L
+  twist.linear.x = v;
+  twist.angular.z = v * std::tan(last_delta_) / wheelbase_;
+  return twist;
+}
+
+Eigen::VectorXd AckermannModel::twistToControl(
+  const geometry_msgs::msg::Twist& twist) const
+{
+  Eigen::VectorXd control(2);
+  control(0) = twist.linear.x;
+  control(1) = 0.0;  // delta_dot은 Twist에서 직접 추출 불가
+  return control;
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/src/motion_model_factory.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/motion_model_factory.cpp
@@ -2,6 +2,7 @@
 #include "mpc_controller_ros2/diff_drive_model.hpp"
 #include "mpc_controller_ros2/swerve_drive_model.hpp"
 #include "mpc_controller_ros2/non_coaxial_swerve_model.hpp"
+#include "mpc_controller_ros2/ackermann_model.hpp"
 #include <stdexcept>
 
 namespace mpc_controller_ros2
@@ -28,10 +29,16 @@ std::unique_ptr<MotionModel> MotionModelFactory::create(
       params.v_min, params.v_max, params.omega_max,
       params.max_steering_rate, params.max_steering_angle);
   }
+  else if (model_type == "ackermann") {
+    return std::make_unique<AckermannModel>(
+      params.v_min, params.v_max,
+      params.max_steering_rate, params.max_steering_angle,
+      params.wheelbase);
+  }
   else {
     throw std::invalid_argument(
       "Unknown motion model type: '" + model_type + "'. "
-      "Supported: 'diff_drive', 'swerve', 'non_coaxial_swerve'");
+      "Supported: 'diff_drive', 'swerve', 'non_coaxial_swerve', 'ackermann'");
   }
 }
 

--- a/ros2_ws/src/mpc_controller_ros2/src/mppi_controller_plugin.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/mppi_controller_plugin.cpp
@@ -1,5 +1,6 @@
 #include "mpc_controller_ros2/mppi_controller_plugin.hpp"
 #include "mpc_controller_ros2/motion_model_factory.hpp"
+#include "mpc_controller_ros2/ackermann_model.hpp"
 #include "mpc_controller_ros2/utils.hpp"
 #include <pluginlib/class_list_macros.hpp>
 #include <tf2/utils.h>
@@ -113,10 +114,15 @@ void MPPIControllerPlugin::configure(
       int nu_dim = dynamics_->model().controlDim();
       Eigen::VectorXd u_min(nu_dim), u_max(nu_dim);
       bool is_nc = (params_.motion_model == "non_coaxial_swerve");
+      bool is_ackermann = (params_.motion_model == "ackermann");
       if (is_nc) {
         // Non-Coaxial: [v, omega, delta_dot]
         u_min << params_.v_min, params_.omega_min, -params_.max_steering_rate;
         u_max << params_.v_max, params_.omega_max,  params_.max_steering_rate;
+      } else if (is_ackermann) {
+        // Ackermann: [v, delta_dot]
+        u_min << params_.v_min, -params_.max_steering_rate;
+        u_max << params_.v_max,  params_.max_steering_rate;
       } else if (nu_dim >= 3) {
         // Swerve: [vx, vy, omega]
         double effective_vy_max = (params_.vy_max > 0) ? params_.vy_max : params_.v_max;
@@ -385,7 +391,7 @@ geometry_msgs::msg::TwistStamped MPPIControllerPlugin::computeVelocityCommands(
       }
     }
 
-    // 6.9. Non-Coaxial: delta 추적 갱신 (controlToTwist 전에 수행)
+    // 6.9. Non-Coaxial / Ackermann: delta 추적 갱신 (controlToTwist 전에 수행)
     if (params_.motion_model == "non_coaxial_swerve") {
       double delta_dot = final_control(2);
       last_delta_ += delta_dot * params_.dt;
@@ -393,6 +399,14 @@ geometry_msgs::msg::TwistStamped MPPIControllerPlugin::computeVelocityCommands(
         -params_.max_steering_angle, params_.max_steering_angle);
       auto& nc_model = dynamic_cast<NonCoaxialSwerveModel&>(dynamics_->model());
       nc_model.setLastDelta(last_delta_);
+    }
+    else if (params_.motion_model == "ackermann") {
+      double delta_dot = final_control(1);  // nu=2 → 인덱스 1
+      last_delta_ += delta_dot * params_.dt;
+      last_delta_ = std::clamp(last_delta_,
+        -params_.max_steering_angle, params_.max_steering_angle);
+      auto& ack_model = dynamic_cast<AckermannModel&>(dynamics_->model());
+      ack_model.setLastDelta(last_delta_);
     }
 
     // 7. Build Twist message (MotionModel 기반 변환)
@@ -1265,9 +1279,10 @@ void MPPIControllerPlugin::declareParameters()
   node_->declare_parameter(prefix + "biased_goto_goal_gain", params_.biased_goto_goal_gain);
   node_->declare_parameter(prefix + "biased_path_following_gain", params_.biased_path_following_gain);
 
-  // Non-Coaxial Swerve 전용 파라미터
+  // Non-Coaxial Swerve / Ackermann 공통 파라미터
   node_->declare_parameter(prefix + "max_steering_rate", params_.max_steering_rate);
   node_->declare_parameter(prefix + "max_steering_angle", params_.max_steering_angle);
+  node_->declare_parameter(prefix + "wheelbase", params_.wheelbase);
 
   // CBF (Control Barrier Function)
   node_->declare_parameter(prefix + "cbf_enabled", params_.cbf_enabled);
@@ -1479,9 +1494,10 @@ void MPPIControllerPlugin::loadParameters()
   params_.biased_goto_goal_gain = node_->get_parameter(prefix + "biased_goto_goal_gain").as_double();
   params_.biased_path_following_gain = node_->get_parameter(prefix + "biased_path_following_gain").as_double();
 
-  // Non-Coaxial Swerve 전용 파라미터
+  // Non-Coaxial Swerve / Ackermann 공통 파라미터
   params_.max_steering_rate = node_->get_parameter(prefix + "max_steering_rate").as_double();
   params_.max_steering_angle = node_->get_parameter(prefix + "max_steering_angle").as_double();
+  params_.wheelbase = node_->get_parameter(prefix + "wheelbase").as_double();
 
   // CBF (Control Barrier Function)
   params_.cbf_enabled = node_->get_parameter(prefix + "cbf_enabled").as_bool();
@@ -1964,9 +1980,13 @@ rcl_interfaces::msg::SetParametersResult MPPIControllerPlugin::onSetParametersCa
             int nu_dim = dynamics_->model().controlDim();
             Eigen::VectorXd u_min(nu_dim), u_max(nu_dim);
             bool is_nc = (params_.motion_model == "non_coaxial_swerve");
+            bool is_ack = (params_.motion_model == "ackermann");
             if (is_nc) {
               u_min << params_.v_min, params_.omega_min, -params_.max_steering_rate;
               u_max << params_.v_max, params_.omega_max,  params_.max_steering_rate;
+            } else if (is_ack) {
+              u_min << params_.v_min, -params_.max_steering_rate;
+              u_max << params_.v_max,  params_.max_steering_rate;
             } else if (nu_dim >= 3) {
               u_min << params_.v_min, -params_.v_max, params_.omega_min;
               u_max << params_.v_max,  params_.v_max, params_.omega_max;

--- a/ros2_ws/src/mpc_controller_ros2/test/unit/test_motion_model.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/test/unit/test_motion_model.cpp
@@ -1,5 +1,5 @@
 /**
- * @brief MotionModel 추상화 + 3종 모델 단위 테스트
+ * @brief MotionModel 추상화 + 4종 모델 단위 테스트
  *
  * Phase 0: 새 파일만 테스트 — 기존 코드 무변경
  */
@@ -9,6 +9,7 @@
 #include "mpc_controller_ros2/diff_drive_model.hpp"
 #include "mpc_controller_ros2/swerve_drive_model.hpp"
 #include "mpc_controller_ros2/non_coaxial_swerve_model.hpp"
+#include "mpc_controller_ros2/ackermann_model.hpp"
 #include "mpc_controller_ros2/motion_model_factory.hpp"
 #include "mpc_controller_ros2/mppi_params.hpp"
 
@@ -727,6 +728,292 @@ TEST(CrossModelTest, SameForwardMotion)
   EXPECT_NEAR(dd_next(0, 0), sw_next(0, 0), 1e-10);
   EXPECT_NEAR(dd_next(0, 1), sw_next(0, 1), 1e-10);
   EXPECT_NEAR(dd_next(0, 2), sw_next(0, 2), 1e-10);
+}
+
+// ============================================================================
+// AckermannModel Tests
+// ============================================================================
+
+class AckermannModelTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // v_min=0, v_max=1.5, max_steering_rate=2.0, max_steering_angle=π/4, wheelbase=0.5
+    model_ = std::make_unique<AckermannModel>(0.0, 1.5, 2.0, M_PI / 4.0, 0.5);
+  }
+  std::unique_ptr<AckermannModel> model_;
+};
+
+TEST_F(AckermannModelTest, Dimensions)
+{
+  EXPECT_EQ(model_->stateDim(), 4);
+  EXPECT_EQ(model_->controlDim(), 2);
+  EXPECT_FALSE(model_->isHolonomic());
+  EXPECT_EQ(model_->name(), "ackermann");
+}
+
+TEST_F(AckermannModelTest, AngleIndices)
+{
+  auto indices = model_->angleIndices();
+  ASSERT_EQ(indices.size(), 1u);
+  EXPECT_EQ(indices[0], 2);
+}
+
+TEST_F(AckermannModelTest, Wheelbase)
+{
+  EXPECT_NEAR(model_->wheelbase(), 0.5, 1e-10);
+}
+
+TEST_F(AckermannModelTest, DynamicsStraight)
+{
+  // v=1, delta=0, delta_dot=0 → 직진
+  Eigen::MatrixXd states(1, 4);
+  states << 0.0, 0.0, 0.0, 0.0;
+  Eigen::MatrixXd controls(1, 2);
+  controls << 1.0, 0.0;
+
+  auto state_dot = model_->dynamicsBatch(states, controls);
+  EXPECT_NEAR(state_dot(0, 0), 1.0, 1e-10);   // x_dot = v*cos(0) = 1
+  EXPECT_NEAR(state_dot(0, 1), 0.0, 1e-10);   // y_dot = v*sin(0) = 0
+  EXPECT_NEAR(state_dot(0, 2), 0.0, 1e-10);   // theta_dot = v*tan(0)/L = 0
+  EXPECT_NEAR(state_dot(0, 3), 0.0, 1e-10);   // delta_dot = 0
+}
+
+TEST_F(AckermannModelTest, DynamicsSteered)
+{
+  // v=1, delta=π/6 (30°), delta_dot=0 → 선회
+  double delta = M_PI / 6.0;
+  Eigen::MatrixXd states(1, 4);
+  states << 0.0, 0.0, 0.0, delta;
+  Eigen::MatrixXd controls(1, 2);
+  controls << 1.0, 0.0;
+
+  auto state_dot = model_->dynamicsBatch(states, controls);
+  EXPECT_NEAR(state_dot(0, 0), 1.0, 1e-10);                          // x_dot = v*cos(0) = 1
+  EXPECT_NEAR(state_dot(0, 1), 0.0, 1e-10);                          // y_dot = v*sin(0) = 0
+  EXPECT_NEAR(state_dot(0, 2), std::tan(delta) / 0.5, 1e-10);       // theta_dot = v*tan(δ)/L
+  EXPECT_NEAR(state_dot(0, 3), 0.0, 1e-10);                          // delta_dot = 0
+}
+
+TEST_F(AckermannModelTest, DynamicsBatch)
+{
+  // 2개 상태 동시 계산
+  Eigen::MatrixXd states(2, 4);
+  states << 0.0, 0.0, 0.0, 0.0,
+            1.0, 2.0, M_PI / 2.0, 0.0;
+  Eigen::MatrixXd controls(2, 2);
+  controls << 1.0, 0.0,
+              0.5, 1.0;
+
+  auto state_dot = model_->dynamicsBatch(states, controls);
+  // 첫 번째: 직진
+  EXPECT_NEAR(state_dot(0, 0), 1.0, 1e-10);
+  EXPECT_NEAR(state_dot(0, 1), 0.0, 1e-10);
+  // 두 번째: theta=90°, v=0.5 → x_dot=0, y_dot=0.5
+  EXPECT_NEAR(state_dot(1, 0), 0.0, 1e-6);
+  EXPECT_NEAR(state_dot(1, 1), 0.5, 1e-10);
+  EXPECT_NEAR(state_dot(1, 3), 1.0, 1e-10);  // delta_dot=1
+}
+
+TEST_F(AckermannModelTest, DynamicsReverse)
+{
+  // 후진: v=-1, delta=0
+  auto model = std::make_unique<AckermannModel>(-1.5, 1.5, 2.0, M_PI / 4.0, 0.5);
+  Eigen::MatrixXd states(1, 4);
+  states << 0.0, 0.0, 0.0, 0.0;
+  Eigen::MatrixXd controls(1, 2);
+  controls << -1.0, 0.0;
+
+  auto state_dot = model->dynamicsBatch(states, controls);
+  EXPECT_NEAR(state_dot(0, 0), -1.0, 1e-10);  // 후진
+  EXPECT_NEAR(state_dot(0, 1), 0.0, 1e-10);
+}
+
+TEST_F(AckermannModelTest, PropagateRK4)
+{
+  // 직진 dt=0.1 → x ≈ 0.1
+  Eigen::MatrixXd states(1, 4);
+  states << 0.0, 0.0, 0.0, 0.0;
+  Eigen::MatrixXd controls(1, 2);
+  controls << 1.0, 0.0;
+
+  auto next = model_->propagateBatch(states, controls, 0.1);
+  EXPECT_NEAR(next(0, 0), 0.1, 1e-6);
+  EXPECT_NEAR(next(0, 1), 0.0, 1e-6);
+  EXPECT_NEAR(next(0, 2), 0.0, 1e-6);
+}
+
+TEST_F(AckermannModelTest, PropagateClamp)
+{
+  // 큰 delta_dot로 여러 스텝 → delta가 ±π/4를 넘지 않아야 함
+  Eigen::MatrixXd states(1, 4);
+  states << 0.0, 0.0, 0.0, 0.0;
+  Eigen::MatrixXd controls(1, 2);
+  controls << 1.0, 5.0;  // delta_dot=5 (큰 값)
+
+  for (int i = 0; i < 50; ++i) {
+    states = model_->propagateBatch(states, controls, 0.05);
+  }
+  EXPECT_LE(states(0, 3), M_PI / 4.0 + 1e-10);
+}
+
+TEST_F(AckermannModelTest, ClipControls)
+{
+  Eigen::MatrixXd controls(3, 2);
+  controls << 2.0, 0.0,      // v=2.0 → 1.5
+              -0.5, 3.0,     // v=-0.5 → 0.0, delta_dot=3.0 → 2.0
+              0.5, -3.0;     // delta_dot=-3.0 → -2.0
+
+  auto clipped = model_->clipControls(controls);
+  EXPECT_NEAR(clipped(0, 0), 1.5, 1e-10);
+  EXPECT_NEAR(clipped(1, 0), 0.0, 1e-10);
+  EXPECT_NEAR(clipped(1, 1), 2.0, 1e-10);
+  EXPECT_NEAR(clipped(2, 1), -2.0, 1e-10);
+}
+
+TEST_F(AckermannModelTest, NormalizeStates)
+{
+  Eigen::MatrixXd states(2, 4);
+  states << 0.0, 0.0, 4.0, 1.0,      // theta=4 → wrap, delta=1.0 → clamp to π/4
+            0.0, 0.0, -4.0, -1.0;    // theta=-4 → wrap, delta=-1.0 → clamp to -π/4
+
+  model_->normalizeStates(states);
+  EXPECT_LT(std::abs(states(0, 2)), M_PI + 1e-10);   // theta wrapped
+  EXPECT_NEAR(states(0, 3), M_PI / 4.0, 1e-10);      // delta clamped
+  EXPECT_NEAR(states(1, 3), -M_PI / 4.0, 1e-10);
+}
+
+TEST_F(AckermannModelTest, ControlToTwist)
+{
+  model_->setLastDelta(M_PI / 6.0);  // 30°
+  Eigen::VectorXd control(2);
+  control << 1.0, 0.0;
+
+  auto twist = model_->controlToTwist(control);
+  EXPECT_NEAR(twist.linear.x, 1.0, 1e-10);
+  EXPECT_NEAR(twist.angular.z, 1.0 * std::tan(M_PI / 6.0) / 0.5, 1e-10);
+}
+
+TEST_F(AckermannModelTest, TwistToControl)
+{
+  geometry_msgs::msg::Twist twist;
+  twist.linear.x = 0.5;
+  twist.angular.z = 1.0;
+
+  auto control = model_->twistToControl(twist);
+  EXPECT_EQ(control.size(), 2);
+  EXPECT_NEAR(control(0), 0.5, 1e-10);
+  EXPECT_NEAR(control(1), 0.0, 1e-10);  // delta_dot=0
+}
+
+TEST_F(AckermannModelTest, LastDelta)
+{
+  EXPECT_NEAR(model_->getLastDelta(), 0.0, 1e-10);
+  model_->setLastDelta(0.3);
+  EXPECT_NEAR(model_->getLastDelta(), 0.3, 1e-10);
+}
+
+TEST_F(AckermannModelTest, TurningRadius)
+{
+  // 선회 반경 = L / tan(δ)
+  // δ=π/6 (30°), L=0.5 → R = 0.5/tan(30°) ≈ 0.866m
+  double delta = M_PI / 6.0;
+  double expected_radius = 0.5 / std::tan(delta);
+
+  Eigen::MatrixXd states(1, 4);
+  states << 0.0, 0.0, 0.0, delta;
+  Eigen::MatrixXd controls(1, 2);
+  controls << 1.0, 0.0;
+
+  auto state_dot = model_->dynamicsBatch(states, controls);
+  double theta_dot = state_dot(0, 2);
+  double v = controls(0, 0);
+  double actual_radius = v / std::abs(theta_dot);
+  EXPECT_NEAR(actual_radius, expected_radius, 1e-6);
+}
+
+TEST_F(AckermannModelTest, Factory)
+{
+  MPPIParams params;
+  params.wheelbase = 0.5;
+  params.max_steering_angle = M_PI / 4.0;
+  auto model = MotionModelFactory::create("ackermann", params);
+  EXPECT_EQ(model->stateDim(), 4);
+  EXPECT_EQ(model->controlDim(), 2);
+  EXPECT_EQ(model->name(), "ackermann");
+}
+
+TEST_F(AckermannModelTest, FactoryError)
+{
+  MPPIParams params;
+  EXPECT_THROW(MotionModelFactory::create("invalid_model", params), std::invalid_argument);
+}
+
+TEST_F(AckermannModelTest, RolloutBatch)
+{
+  // K=2 궤적, N=5 스텝 롤아웃
+  Eigen::VectorXd x0(4);
+  x0 << 0.0, 0.0, 0.0, 0.0;
+
+  std::vector<Eigen::MatrixXd> control_sequences(2);
+  for (int k = 0; k < 2; ++k) {
+    control_sequences[k] = Eigen::MatrixXd::Zero(5, 2);
+    control_sequences[k].col(0).setConstant(1.0);  // v=1
+  }
+
+  auto trajectories = model_->rolloutBatch(x0, control_sequences, 0.1);
+  ASSERT_EQ(trajectories.size(), 2u);
+  EXPECT_EQ(trajectories[0].rows(), 6);  // N+1 = 6
+  EXPECT_EQ(trajectories[0].cols(), 4);  // nx=4
+  // 직진 → x 증가
+  EXPECT_GT(trajectories[0](5, 0), 0.4);
+}
+
+TEST_F(AckermannModelTest, InPlaceRollout)
+{
+  Eigen::VectorXd x0(4);
+  x0 << 0.0, 0.0, 0.0, 0.0;
+
+  std::vector<Eigen::MatrixXd> control_sequences(2);
+  for (int k = 0; k < 2; ++k) {
+    control_sequences[k] = Eigen::MatrixXd::Zero(5, 2);
+    control_sequences[k].col(0).setConstant(0.5);
+  }
+
+  std::vector<Eigen::MatrixXd> trajectories_out;
+  model_->rolloutBatchInPlace(x0, control_sequences, 0.1, trajectories_out);
+
+  ASSERT_EQ(trajectories_out.size(), 2u);
+  EXPECT_EQ(trajectories_out[0].rows(), 6);
+  EXPECT_EQ(trajectories_out[0].cols(), 4);
+}
+
+// ============================================================================
+// Ackermann vs NonCoaxial 비교: delta=0 직진 동역학 일치
+// ============================================================================
+
+TEST(AckermannCrossModelTest, StraightMatchesDiffDrive)
+{
+  // delta=0일 때 Ackermann과 DiffDrive의 직진 동역학은 동일해야 함
+  auto ack = std::make_unique<AckermannModel>(0.0, 2.0, 2.0, M_PI / 4.0, 0.5);
+  auto dd = std::make_unique<DiffDriveModel>(0.0, 2.0, -2.0, 2.0);
+
+  Eigen::MatrixXd ack_states(1, 4), dd_states(1, 3);
+  ack_states << 0.0, 0.0, 0.0, 0.0;
+  dd_states << 0.0, 0.0, 0.0;
+
+  Eigen::MatrixXd ack_controls(1, 2), dd_controls(1, 2);
+  ack_controls << 1.0, 0.0;
+  dd_controls << 1.0, 0.0;
+
+  auto ack_next = ack->propagateBatch(ack_states, ack_controls, 0.1);
+  auto dd_next = dd->propagateBatch(dd_states, dd_controls, 0.1);
+
+  // x, y, theta는 동일
+  EXPECT_NEAR(ack_next(0, 0), dd_next(0, 0), 1e-10);
+  EXPECT_NEAR(ack_next(0, 1), dd_next(0, 1), 1e-10);
+  EXPECT_NEAR(ack_next(0, 2), dd_next(0, 2), 1e-10);
 }
 
 int main(int argc, char** argv)

--- a/ros2_ws/src/mpc_controller_ros2/urdf/ackermann_robot.urdf
+++ b/ros2_ws/src/mpc_controller_ros2/urdf/ackermann_robot.urdf
@@ -1,0 +1,395 @@
+<?xml version="1.0"?>
+<robot name="ackermann_robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- Controller config path (passed from launch file) -->
+  <xacro:arg name="controller_config" default=""/>
+
+  <!-- Robot dimensions (Bicycle model: wheelbase=0.5m, track=0.4m) -->
+  <xacro:property name="base_width" value="0.4"/>
+  <xacro:property name="base_length" value="0.6"/>
+  <xacro:property name="base_height" value="0.15"/>
+  <xacro:property name="wheelbase" value="0.5"/>
+  <xacro:property name="track_width" value="0.4"/>
+  <xacro:property name="wheel_radius" value="0.1"/>
+  <xacro:property name="wheel_width" value="0.05"/>
+  <xacro:property name="max_steer_angle" value="0.7854"/>  <!-- ~45deg -->
+
+  <!-- ============================================================ -->
+  <!-- Base link (robot body) -->
+  <!-- ============================================================ -->
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0"/>
+      <geometry>
+        <box size="${base_length} ${base_width} ${base_height}"/>
+      </geometry>
+      <material name="green">
+        <color rgba="0.2 0.6 0.3 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0.05" rpy="0 0 0"/>
+      <geometry>
+        <box size="${base_length} ${base_width} ${base_height}"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0.03" rpy="0 0 0"/>
+      <mass value="20.0"/>
+      <!-- ixx=m/12*(w^2+h^2)=0.30, iyy=m/12*(l^2+h^2)=0.64, izz=m/12*(l^2+w^2)=0.87 -->
+      <inertia ixx="0.30" ixy="0.0" ixz="0.0"
+               iyy="0.64" iyz="0.0"
+               izz="0.87"/>
+    </inertial>
+  </link>
+
+  <!-- ============================================================ -->
+  <!-- Rear wheels (traction, velocity command) -->
+  <!-- ============================================================ -->
+  <link name="rear_left_wheel">
+    <visual>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0.1 0.1 0.1 1.0"/>
+      </material>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0054" ixy="0.0" ixz="0.0"
+               iyy="0.0054" iyz="0.0"
+               izz="0.01"/>
+    </inertial>
+  </link>
+
+  <joint name="rear_left_wheel_joint" type="continuous">
+    <parent link="base_link"/>
+    <child link="rear_left_wheel"/>
+    <origin xyz="${-wheelbase/2} ${track_width/2} 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <dynamics damping="0.1" friction="0.1"/>
+  </joint>
+
+  <link name="rear_right_wheel">
+    <visual>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0.1 0.1 0.1 1.0"/>
+      </material>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0054" ixy="0.0" ixz="0.0"
+               iyy="0.0054" iyz="0.0"
+               izz="0.01"/>
+    </inertial>
+  </link>
+
+  <joint name="rear_right_wheel_joint" type="continuous">
+    <parent link="base_link"/>
+    <child link="rear_right_wheel"/>
+    <origin xyz="${-wheelbase/2} ${-track_width/2} 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <dynamics damping="0.1" friction="0.1"/>
+  </joint>
+
+  <!-- ============================================================ -->
+  <!-- Front steering + wheels (steer position command, wheel read-only) -->
+  <!-- ============================================================ -->
+
+  <!-- Front Left Steer -->
+  <link name="front_left_steer_link">
+    <visual>
+      <geometry>
+        <cylinder radius="0.02" length="0.05"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1.0"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="0.5"/>
+      <inertia ixx="0.0002" ixy="0.0" ixz="0.0"
+               iyy="0.0002" iyz="0.0"
+               izz="0.0002"/>
+    </inertial>
+  </link>
+
+  <joint name="front_left_steer_joint" type="revolute">
+    <parent link="base_link"/>
+    <child link="front_left_steer_link"/>
+    <origin xyz="${wheelbase/2} ${track_width/2} 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="${-max_steer_angle}" upper="${max_steer_angle}"
+           velocity="5.0" effort="100.0"/>
+    <dynamics damping="0.05" friction="0.05"/>
+  </joint>
+
+  <link name="front_left_wheel">
+    <visual>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0.1 0.1 0.1 1.0"/>
+      </material>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0054" ixy="0.0" ixz="0.0"
+               iyy="0.0054" iyz="0.0"
+               izz="0.01"/>
+    </inertial>
+  </link>
+
+  <joint name="front_left_wheel_joint" type="continuous">
+    <parent link="front_left_steer_link"/>
+    <child link="front_left_wheel"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <dynamics damping="0.1" friction="0.1"/>
+  </joint>
+
+  <!-- Front Right Steer -->
+  <link name="front_right_steer_link">
+    <visual>
+      <geometry>
+        <cylinder radius="0.02" length="0.05"/>
+      </geometry>
+      <material name="gray">
+        <color rgba="0.5 0.5 0.5 1.0"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="0.5"/>
+      <inertia ixx="0.0002" ixy="0.0" ixz="0.0"
+               iyy="0.0002" iyz="0.0"
+               izz="0.0002"/>
+    </inertial>
+  </link>
+
+  <joint name="front_right_steer_joint" type="revolute">
+    <parent link="base_link"/>
+    <child link="front_right_steer_link"/>
+    <origin xyz="${wheelbase/2} ${-track_width/2} 0" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="${-max_steer_angle}" upper="${max_steer_angle}"
+           velocity="5.0" effort="100.0"/>
+    <dynamics damping="0.05" friction="0.05"/>
+  </joint>
+
+  <link name="front_right_wheel">
+    <visual>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <material name="black">
+        <color rgba="0.1 0.1 0.1 1.0"/>
+      </material>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder radius="${wheel_radius}" length="${wheel_width}"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+    </collision>
+    <inertial>
+      <origin xyz="0 0 0" rpy="${pi/2} 0 0"/>
+      <mass value="2.0"/>
+      <inertia ixx="0.0054" ixy="0.0" ixz="0.0"
+               iyy="0.0054" iyz="0.0"
+               izz="0.01"/>
+    </inertial>
+  </link>
+
+  <joint name="front_right_wheel_joint" type="continuous">
+    <parent link="front_right_steer_link"/>
+    <child link="front_right_wheel"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <dynamics damping="0.1" friction="0.1"/>
+  </joint>
+
+  <!-- ============================================================ -->
+  <!-- Lidar sensor -->
+  <!-- ============================================================ -->
+  <link name="lidar_link">
+    <visual>
+      <geometry>
+        <cylinder radius="0.05" length="0.05"/>
+      </geometry>
+      <material name="red">
+        <color rgba="0.8 0.2 0.2 1.0"/>
+      </material>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder radius="0.05" length="0.05"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0.0001" ixy="0.0" ixz="0.0"
+               iyy="0.0001" iyz="0.0"
+               izz="0.0001"/>
+    </inertial>
+  </link>
+
+  <joint name="lidar_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="lidar_link"/>
+    <origin xyz="0.15 0 0.35" rpy="0 -0.087 0"/>
+  </joint>
+
+  <!-- ============================================================ -->
+  <!-- ros2_control: Ackermann steering -->
+  <!-- ============================================================ -->
+  <ros2_control name="GazeboSystem" type="system">
+    <hardware>
+      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+    </hardware>
+
+    <!-- Rear wheels: velocity command (traction) -->
+    <joint name="rear_left_wheel_joint">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="rear_right_wheel_joint">
+      <command_interface name="velocity"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+
+    <!-- Front steering: position command -->
+    <joint name="front_left_steer_joint">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+    <joint name="front_right_steer_joint">
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+    </joint>
+
+    <!-- Front wheels: state only (read-only, passive rolling) -->
+    <joint name="front_left_wheel_joint">
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+    <joint name="front_right_wheel_joint">
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+    </joint>
+  </ros2_control>
+
+  <!-- Gazebo Harmonic gz_ros2_control plugin -->
+  <gazebo>
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+      <parameters>$(arg controller_config)</parameters>
+    </plugin>
+  </gazebo>
+
+  <!-- Gazebo OdometryPublisher (ground truth odom) -->
+  <gazebo>
+    <plugin filename="gz-sim-odometry-publisher-system"
+            name="gz::sim::systems::OdometryPublisher">
+      <odom_frame>odom</odom_frame>
+      <robot_base_frame>base_link</robot_base_frame>
+      <odom_publish_frequency>50</odom_publish_frequency>
+      <dimensions>3</dimensions>
+    </plugin>
+  </gazebo>
+
+  <!-- Lidar sensor for Gazebo Harmonic -->
+  <gazebo reference="lidar_link">
+    <sensor name="lidar" type="gpu_lidar">
+      <topic>/scan</topic>
+      <update_rate>20</update_rate>
+      <gz_frame_id>lidar_link</gz_frame_id>
+      <lidar>
+        <scan>
+          <horizontal>
+            <samples>720</samples>
+            <resolution>1.0</resolution>
+            <min_angle>-3.14159</min_angle>
+            <max_angle>3.14159</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.25</min>
+          <max>20.0</max>
+          <resolution>0.01</resolution>
+        </range>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.005</stddev>
+        </noise>
+      </lidar>
+      <always_on>1</always_on>
+      <visualize>true</visualize>
+    </sensor>
+  </gazebo>
+
+  <!-- Gazebo surface properties -->
+  <gazebo reference="rear_left_wheel">
+    <mu1>1.2</mu1>
+    <mu2>0.5</mu2>
+    <kp>1000000</kp>
+    <kd>100</kd>
+    <minDepth>0.001</minDepth>
+  </gazebo>
+
+  <gazebo reference="rear_right_wheel">
+    <mu1>1.2</mu1>
+    <mu2>0.5</mu2>
+    <kp>1000000</kp>
+    <kd>100</kd>
+    <minDepth>0.001</minDepth>
+  </gazebo>
+
+  <gazebo reference="front_left_wheel">
+    <mu1>1.0</mu1>
+    <mu2>0.4</mu2>
+    <kp>1000000</kp>
+    <kd>100</kd>
+    <minDepth>0.001</minDepth>
+  </gazebo>
+
+  <gazebo reference="front_right_wheel">
+    <mu1>1.0</mu1>
+    <mu2>0.4</mu2>
+    <kp>1000000</kp>
+    <kd>100</kd>
+    <minDepth>0.001</minDepth>
+  </gazebo>
+
+</robot>


### PR DESCRIPTION
## Summary
- Bicycle model 기반 Ackermann MotionModel C++ 구현 (nx=4 `[x,y,θ,δ]`, nu=2 `[v,δ̇]`)
- 핵심 동역학: `θ̇ = v·tan(δ)/L` (wheelbase 파라미터)
- MotionModelFactory, CBF, Plugin 완전 통합 + Gazebo URDF/launch 지원

## 변경 사항

### 신규 파일 (5개)
| 파일 | 설명 |
|------|------|
| `ackermann_model.hpp/cpp` | Bicycle model 동역학 (dynamicsBatch, RK4, clipControls 등) |
| `ackermann_robot.urdf` | 4륜 Ackermann URDF (전륜 조향 + 후륜 구동 + Lidar + OdometryPublisher) |
| `ackermann_steering_controller.yaml` | ros2_control Ackermann 스티어링 컨트롤러 설정 |
| `nav2_params_ackermann_mppi.yaml` | nav2 MPPI 파라미터 (motion_model=ackermann) |

### 수정 파일 (6개)
| 파일 | 변경 |
|------|------|
| `motion_model_factory.cpp` | `"ackermann"` 분기 추가 |
| `mppi_params.hpp` | `wheelbase{0.5}` 파라미터 추가 |
| `mppi_controller_plugin.cpp` | CBF bounds + last_delta_ 추적 (Ackermann) |
| `launch.py` | `controller:=ackermann` 분기 (URDF/config/spawner/bridge) |
| `CMakeLists.txt` | `src/ackermann_model.cpp` 추가 |
| `test_motion_model.cpp` | 20개 Ackermann gtest 추가 |

## Ackermann vs NonCoaxialSwerve 비교

```
              Ackermann              NonCoaxialSwerve
State:   [x, y, θ, δ]  (nx=4)   [x, y, θ, δ]  (nx=4)
Control: [v, δ̇]        (nu=2)   [v, ω, δ̇]    (nu=3)
θ̇:       v·tan(δ)/L (구속)       ω (독립 제어)
Twist:   linear.x=v              linear.x=v·cos(δ)
         angular.z=v·tan(δ)/L    linear.y=v·sin(δ)
```

## Test plan
- [x] 빌드 성공: `colcon build --packages-select mpc_controller_ros2`
- [x] 전체 gtest PASS: 68/68 (기존 48 + Ackermann 20)
- [ ] E2E 시뮬레이션: `ros2 launch ... controller:=ackermann`

🤖 Generated with [Claude Code](https://claude.com/claude-code)