### PR TITLE
feat: 다중 CBF 합성 + Online Residual Learning + Predictive Safety Filter

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
+++ b/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
@@ -118,6 +118,10 @@ add_library(mppi_controller_plugin SHARED
   src/clf_function.cpp
   src/clf_cbf_qp_solver.cpp
   src/clf_cbf_mppi_controller_plugin.cpp
+  src/online_data_collector.cpp
+  src/model_reloader.cpp
+  src/predictive_safety_filter.cpp
+  src/predictive_safety_mppi_controller_plugin.cpp
 )
 
 target_include_directories(mppi_controller_plugin PUBLIC
@@ -371,6 +375,21 @@ if(BUILD_TESTING)
   ament_add_gtest(test_clf_cbf_qp test/unit/test_clf_cbf_qp.cpp)
   if(TARGET test_clf_cbf_qp)
     target_link_libraries(test_clf_cbf_qp mppi_controller_plugin)
+  endif()
+
+  ament_add_gtest(test_cbf_composition test/unit/test_cbf_composition.cpp)
+  if(TARGET test_cbf_composition)
+    target_link_libraries(test_cbf_composition mppi_controller_plugin)
+  endif()
+
+  ament_add_gtest(test_online_learning test/unit/test_online_learning.cpp)
+  if(TARGET test_online_learning)
+    target_link_libraries(test_online_learning mppi_controller_plugin)
+  endif()
+
+  ament_add_gtest(test_predictive_safety test/unit/test_predictive_safety.cpp)
+  if(TARGET test_predictive_safety)
+    target_link_libraries(test_predictive_safety mppi_controller_plugin)
   endif()
 endif()
 

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_predictive_safety_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_predictive_safety_mppi.yaml
@@ -1,0 +1,124 @@
+# ============================================================
+# nav2 파라미터 - Predictive Safety MPPI (N-step CBF 투영)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py \
+#       controller:=predictive_safety
+#
+# 특징:
+#   - PredictiveSafetyMPPIControllerPlugin: ShieldMPPI 상속
+#   - N-step forward rollout + CBF 투영 → recursive feasibility
+#   - 보정 전파: step t에서의 보정이 step t+1..N에 영향
+#   - horizon_decay로 시간에 따른 CBF 강도 조절
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    progress_checker:
+      required_movement_radius: 0.1
+      movement_time_allowance: 60.0
+
+    goal_checker:
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.5
+
+    # ---- Predictive Safety MPPI Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::PredictiveSafetyMPPIControllerPlugin"
+      motion_model: "diff_drive"
+
+      # 예측 지평선 (3초)
+      N: 30
+      dt: 0.1
+
+      # 샘플링
+      K: 256
+      lambda: 10.0
+
+      # 노이즈
+      noise_sigma_v: 0.4
+      noise_sigma_omega: 0.4
+
+      # 제어 제약
+      v_max: 0.5
+      v_min: -0.1
+      omega_max: 1.5
+      omega_min: -1.5
+
+      # 상태 추종 가중치
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 1.0
+
+      # 터미널 비용
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 2.0
+
+      # 제어 비용
+      R_v: 0.5
+      R_omega: 0.3
+
+      # 제어 변화율 비용
+      R_rate_v: 2.0
+      R_rate_omega: 1.0
+
+      # 장애물 회피
+      obstacle_weight: 100.0
+      safety_distance: 0.4
+
+      # Costmap
+      use_costmap_cost: true
+      costmap_lethal_cost: 500.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 0.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 1.5
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.5
+
+      # ---- CBF 안전 필터 ----
+      cbf_enabled: true
+      cbf_gamma: 0.5
+      cbf_safety_margin: 0.3
+      cbf_robot_radius: 0.2
+      cbf_activation_distance: 2.0
+      cbf_use_safety_filter: false
+
+      # ---- Shield-MPPI (per-step) ----
+      shield_cbf_stride: 3
+      shield_max_iterations: 5
+
+      # ---- Predictive Safety Filter ----
+      predictive_safety_enabled: true
+      predictive_safety_horizon: 0        # 0 = 전체 horizon N
+      predictive_safety_decay: 0.95       # gamma 시간 감쇠
+      predictive_safety_max_iterations: 8 # 스텝당 최대 투영 반복
+
+      # ---- BR-MPPI ----
+      barrier_rate_cost_weight: 10.0
+
+      # ---- Conformal Predictor ----
+      conformal_enabled: true
+      conformal_coverage: 0.90
+      conformal_window_size: 100
+      conformal_initial_margin: 0.1
+      conformal_min_margin: 0.05
+      conformal_max_margin: 0.3
+
+      # 궤적 안정화
+      sg_filter_enabled: true
+      sg_half_window: 3
+      sg_poly_order: 3
+      it_alpha: 0.98
+      exploration_ratio: 0.05
+
+      # 시각화
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/barrier_function.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/barrier_function.hpp
@@ -9,6 +9,19 @@ namespace mpc_controller_ros2
 {
 
 /**
+ * @brief CBF 합성 전략
+ *
+ * 다중 CBF를 하나의 합성 CBF로 결합하여 제약 수를 줄이고
+ * QP 수렴을 개선합니다.
+ */
+enum class CBFCompositionMethod {
+  MIN,           ///< h_c = min(h_1, ..., h_n) — 가장 보수적, 비미분
+  SMOOTH_MIN,    ///< h_c = -1/α · log(Σ exp(-α·h_i)) — 미분 가능 근사
+  LOG_SUM_EXP,   ///< h_c = -log(Σ exp(-h_i)) — smooth min 특수 경우 (α=1)
+  PRODUCT        ///< h_c = Π h_i — 모든 배리어 동시 반영
+};
+
+/**
  * @brief 원형 장애물 CBF (Control Barrier Function)
  *
  * h(x) = ||p - p_obs||² - d_safe²
@@ -107,6 +120,36 @@ public:
 
   /** @brief alpha_safe setter (C3BF 콘 반각) */
   void setAlphaSafe(double alpha_safe) { alpha_safe_ = alpha_safe; }
+
+  // =========================================================================
+  // CBF 합성 메서드 (다중 CBF → 단일 합성 CBF)
+  // =========================================================================
+
+  /**
+   * @brief 합성 CBF 값: h_c(x)
+   *
+   * 활성 barrier들을 합성하여 단일 CBF 값을 반환합니다.
+   * @param state 현재 상태 (nx,)
+   * @param method 합성 방법
+   * @param alpha smooth-min 파라미터 (클수록 min에 가까움)
+   * @return 합성 CBF 값 h_c(x)
+   */
+  double evaluateComposite(const Eigen::VectorXd& state,
+                           CBFCompositionMethod method = CBFCompositionMethod::SMOOTH_MIN,
+                           double alpha = 10.0) const;
+
+  /**
+   * @brief 합성 CBF gradient: ∇h_c(x)
+   *
+   * 활성 barrier들의 합성 gradient를 반환합니다.
+   * @param state 현재 상태 (nx,)
+   * @param method 합성 방법
+   * @param alpha smooth-min 파라미터
+   * @return ∇h_c(x) (nx,)
+   */
+  Eigen::VectorXd compositeGradient(const Eigen::VectorXd& state,
+                                     CBFCompositionMethod method = CBFCompositionMethod::SMOOTH_MIN,
+                                     double alpha = 10.0) const;
 
 private:
   double robot_radius_;

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/clf_cbf_qp_solver.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/clf_cbf_qp_solver.hpp
@@ -72,6 +72,28 @@ public:
     const BatchDynamicsWrapper& dynamics) const;
 
   /**
+   * @brief 합성 CBF 단일 제약으로 CLF-CBF-QP 해결
+   *
+   * 다중 CBF를 합성하여 단일 제약으로 QP를 해결합니다.
+   * 제약 수 감소 + 미분 가능성 보장 → QP 수렴 개선.
+   *
+   * @param state 현재 상태 (nx,)
+   * @param x_des 목표 상태 (nx,)
+   * @param u_ref MPPI 참조 제어 (nu,)
+   * @param dynamics 동역학 래퍼
+   * @param method CBF 합성 방법
+   * @param composition_alpha smooth-min 파라미터
+   * @return QP 결과 (cbf_margins는 합성 CBF 단일 마진)
+   */
+  CLFCBFQPResult solveComposite(
+    const Eigen::VectorXd& state,
+    const Eigen::VectorXd& x_des,
+    const Eigen::VectorXd& u_ref,
+    const BatchDynamicsWrapper& dynamics,
+    CBFCompositionMethod method = CBFCompositionMethod::SMOOTH_MIN,
+    double composition_alpha = 10.0) const;
+
+  /**
    * @brief CLF만으로 QP 해결 (CBF 제약 없음)
    */
   CLFCBFQPResult solveCLFOnly(

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/ensemble_dynamics_model.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/ensemble_dynamics_model.hpp
@@ -4,6 +4,7 @@
 #include "mpc_controller_ros2/motion_model.hpp"
 #include "mpc_controller_ros2/eigen_mlp.hpp"
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace mpc_controller_ros2
@@ -81,10 +82,23 @@ public:
   /** @brief 내부 공칭 모델 접근 */
   const MotionModel& nominal() const { return *nominal_; }
 
+  /**
+   * @brief 앙상블 MLP 핫스왑 (thread-safe)
+   *
+   * dynamicsBatch/predictWithUncertainty 실행 중에도 안전하게
+   * 앙상블을 교체합니다.
+   */
+  void updateEnsemble(std::vector<std::unique_ptr<EigenMLP>> new_ensemble);
+
+  /** @brief 모델 버전 (핫스왑 카운터) */
+  int modelVersion() const { return model_version_; }
+
 private:
   std::unique_ptr<MotionModel> nominal_;
   std::vector<std::unique_ptr<EigenMLP>> ensemble_;
   double alpha_;
+  mutable std::mutex ensemble_mutex_;  // 핫스왑 보호
+  int model_version_{0};
 
   /** @brief MLP 입력 특성 구성: [states | controls] */
   Eigen::MatrixXd buildFeatures(

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/model_reloader.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/model_reloader.hpp
@@ -1,0 +1,73 @@
+#ifndef MPC_CONTROLLER_ROS2__MODEL_RELOADER_HPP_
+#define MPC_CONTROLLER_ROS2__MODEL_RELOADER_HPP_
+
+#include "mpc_controller_ros2/eigen_mlp.hpp"
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief 디스크에서 앙상블 MLP 모델 핫 리로드
+ *
+ * weights_dir 디렉토리에서 model_0.bin ~ model_{M-1}.bin 파일을
+ * 모니터링하고, 타임스탬프 변경 시 새 모델을 로드합니다.
+ *
+ * 사용 패턴:
+ *   1. 주기적으로 modelsUpdated() 확인
+ *   2. 변경 감지 시 tryReload() 호출
+ *   3. 성공하면 takeModels()로 새 앙상블 획득
+ */
+class ModelReloader
+{
+public:
+  /**
+   * @param weights_dir 모델 파일 디렉토리
+   * @param ensemble_size 앙상블 MLP 수 (M)
+   */
+  ModelReloader(const std::string& weights_dir, int ensemble_size);
+
+  /**
+   * @brief 디스크에서 최신 모델 로드 시도
+   * @return true if new model loaded successfully
+   */
+  bool tryReload();
+
+  /**
+   * @brief 현재 로드된 앙상블 MLP 반환 (소유권 이전)
+   *
+   * tryReload() 성공 후 호출. 호출 후 내부 벡터는 비워짐.
+   */
+  std::vector<std::unique_ptr<EigenMLP>> takeModels();
+
+  /** @brief 마지막 로드 시간 */
+  std::chrono::steady_clock::time_point lastReloadTime() const { return last_reload_time_; }
+
+  /** @brief 모델 파일 전부 존재 확인 */
+  bool modelsExist() const;
+
+  /**
+   * @brief 모델 파일 타임스탬프 변경 확인
+   *
+   * 최초 호출 시 또는 타임스탬프 변경 감지 시 true 반환.
+   */
+  bool modelsUpdated() const;
+
+private:
+  std::string weights_dir_;
+  int ensemble_size_;
+  mutable std::vector<std::filesystem::file_time_type> last_timestamps_;
+  std::chrono::steady_clock::time_point last_reload_time_;
+  std::vector<std::unique_ptr<EigenMLP>> loaded_models_;
+
+  /** @brief i번째 모델 파일 경로 */
+  std::string modelPath(int i) const;
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__MODEL_RELOADER_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/mppi_params.hpp
@@ -211,6 +211,12 @@ struct MPPIParams
   std::string online_data_export_path{"/tmp/mppi_online_data.csv"};  // 내보내기 경로
 
   // ============================================================================
+  // Online Learning (런타임 모델 리로드)
+  // ============================================================================
+  bool model_reload_enabled{false};                // 모델 리로드 체크 활성화
+  double model_reload_interval_sec{30.0};          // 모델 리로드 체크 간격 (초)
+
+  // ============================================================================
   // Safety Enhancement 파라미터
   // ============================================================================
 
@@ -238,6 +244,22 @@ struct MPPIParams
   double clf_decay_rate{1.0};                      // CLF decay rate c (V̇ + c·V ≤ δ)
   double clf_slack_penalty{100.0};                 // slack 페널티 p (min p·δ²)
   double clf_P_scale{1.0};                         // P = scale · Q (Lyapunov 가중치)
+
+  // ============================================================================
+  // CBF 합성 파라미터 (다중 CBF → 단일 합성 CBF)
+  // ============================================================================
+  bool cbf_composition_enabled{false};       // 합성 CBF 활성화
+  int cbf_composition_method{1};             // 0=MIN, 1=SMOOTH_MIN, 2=LOG_SUM_EXP, 3=PRODUCT
+  double cbf_composition_alpha{10.0};        // smooth-min 파라미터 (클수록 min에 가까움)
+
+  // ============================================================================
+  // Predictive Safety Filter 파라미터 (N-step CBF 투영)
+  // ShieldMPPI의 단일 스텝 투영을 전체 horizon으로 확장
+  // ============================================================================
+  bool predictive_safety_enabled{false};     // 예측 안전 필터 활성화
+  int predictive_safety_horizon{0};          // 투영 horizon (0=전체 N)
+  double predictive_safety_decay{1.0};       // gamma 시간 감쇠 (1.0=균일)
+  int predictive_safety_max_iterations{10};  // 스텝당 최대 투영 반복
 
   // ============================================================================
   // Covariance Steering MPPI (CS-MPPI) 파라미터

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/online_data_collector.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/online_data_collector.hpp
@@ -1,0 +1,69 @@
+#ifndef MPC_CONTROLLER_ROS2__ONLINE_DATA_COLLECTOR_HPP_
+#define MPC_CONTROLLER_ROS2__ONLINE_DATA_COLLECTOR_HPP_
+
+#include "mpc_controller_ros2/online_data_buffer.hpp"
+#include "mpc_controller_ros2/motion_model.hpp"
+#include <Eigen/Dense>
+#include <atomic>
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief 온라인 데이터 수집기
+ *
+ * 매 제어 주기마다 (prev_state, prev_control, curr_state, dt) 데이터를
+ * OnlineDataBuffer에 수집합니다. MotionModel의 차원 정보를 사용하여
+ * 입력 검증을 수행합니다.
+ *
+ * Thread-safe: enabled_ 플래그는 atomic, buffer는 자체 mutex 보호.
+ */
+class OnlineDataCollector
+{
+public:
+  struct Stats {
+    size_t total_collected{0};
+    size_t buffer_size{0};
+    bool buffer_full{false};
+  };
+
+  /**
+   * @param buffer 데이터 저장 버퍼 (비소유, 수명 보장 필요)
+   * @param model 동역학 모델 (비소유, 차원 검증용)
+   * @param state_dim 상태 차원
+   * @param control_dim 제어 차원
+   */
+  OnlineDataCollector(OnlineDataBuffer* buffer,
+                      const MotionModel* model,
+                      int state_dim, int control_dim);
+
+  /**
+   * @brief 매 제어 주기마다 호출 — 데이터 포인트 수집
+   *
+   * enabled_가 false이면 무시.
+   * 차원 불일치 시 무시 (silent skip).
+   */
+  void collect(const Eigen::VectorXd& prev_state,
+               const Eigen::VectorXd& prev_control,
+               const Eigen::VectorXd& curr_state,
+               double dt);
+
+  /** @brief 수집 통계 */
+  Stats getStats() const;
+
+  /** @brief 수집 활성화/비활성화 */
+  void setEnabled(bool enabled) { enabled_ = enabled; }
+  bool isEnabled() const { return enabled_; }
+
+private:
+  OnlineDataBuffer* buffer_;  // 비소유
+  const MotionModel* model_;  // 비소유
+  int nx_;
+  int nu_;
+  std::atomic<bool> enabled_{true};
+  std::atomic<size_t> total_collected_{0};
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__ONLINE_DATA_COLLECTOR_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/predictive_safety_filter.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/predictive_safety_filter.hpp
@@ -1,0 +1,130 @@
+#ifndef MPC_CONTROLLER_ROS2__PREDICTIVE_SAFETY_FILTER_HPP_
+#define MPC_CONTROLLER_ROS2__PREDICTIVE_SAFETY_FILTER_HPP_
+
+#include <Eigen/Dense>
+#include <vector>
+#include "mpc_controller_ros2/barrier_function.hpp"
+#include "mpc_controller_ros2/motion_model.hpp"
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief N-step 예측 안전 필터 결과
+ */
+struct PredictiveSafetyResult {
+  Eigen::MatrixXd u_safe_sequence;   // (N x nu) 안전 제어 시퀀스
+  Eigen::MatrixXd safe_trajectory;   // ((N+1) x nx) 안전 궤적
+  bool feasible{false};
+  int num_corrected_steps{0};        // CBF 투영이 적용된 스텝 수
+  std::vector<double> min_barrier_values;  // 각 스텝의 최소 barrier 값
+};
+
+/**
+ * @brief N-step Predictive Safety Filter (MPC-CBF)
+ *
+ * 전체 제어 시퀀스를 forward rollout하면서 각 스텝에서
+ * CBF 제약 위반 시 투영 보정. 이전 스텝의 보정이 이후 스텝에
+ * 전파되어 recursive feasibility를 보장합니다.
+ *
+ * ShieldMPPI와의 차이:
+ *   - ShieldMPPI: 처음 몇 스텝만 투영 (stride 기반)
+ *   - PredictiveSafety: 전체 horizon 투영 → recursive feasibility 보장
+ *
+ * 알고리즘:
+ *   for t = 0..N-1:
+ *     γ_t = gamma * decay^t
+ *     for each active barrier:
+ *       if ḣ + γ_t·h < 0:
+ *         u_t ← projected gradient step
+ *     x_{t+1} = f(x_t, u_t)
+ */
+class PredictiveSafetyFilter {
+public:
+  /**
+   * @brief 생성자
+   * @param barrier_set 장애물 barrier 집합 (비소유)
+   * @param gamma CBF class-K 함수 계수
+   * @param dt 시간 간격 (초)
+   * @param u_min 제어 입력 하한 (nu,)
+   * @param u_max 제어 입력 상한 (nu,)
+   */
+  PredictiveSafetyFilter(BarrierFunctionSet* barrier_set,
+                         double gamma, double dt,
+                         const Eigen::VectorXd& u_min,
+                         const Eigen::VectorXd& u_max);
+
+  /**
+   * @brief N-step 예측 안전 필터
+   *
+   * 전체 제어 시퀀스를 forward rollout하면서
+   * 각 스텝에서 CBF 제약 위반 시 투영 보정.
+   *
+   * @param x0 초기 상태 (nx,)
+   * @param control_sequence 제어 시퀀스 (N x nu)
+   * @param model 동역학 모델
+   * @return 안전 제어 시퀀스 + 궤적
+   */
+  PredictiveSafetyResult filter(
+    const Eigen::VectorXd& x0,
+    const Eigen::MatrixXd& control_sequence,
+    const MotionModel& model) const;
+
+  /**
+   * @brief 궤적 안전성 검증 (투영 없이 확인만)
+   * @return 모든 스텝에서 CBF 만족 여부
+   */
+  bool verifyTrajectory(
+    const Eigen::VectorXd& x0,
+    const Eigen::MatrixXd& control_sequence,
+    const MotionModel& model) const;
+
+  /** @brief 최대 투영 반복 설정 */
+  void setMaxIterations(int max_iter) { max_iterations_ = max_iter; }
+
+  /** @brief 감쇠 감마 설정 (시간에 따른 CBF 강도 조절) */
+  void setHorizonDecay(double decay) { horizon_decay_ = decay; }
+
+  /** @brief 현재 max_iterations 반환 */
+  int maxIterations() const { return max_iterations_; }
+
+  /** @brief 현재 horizon_decay 반환 */
+  double horizonDecay() const { return horizon_decay_; }
+
+private:
+  /**
+   * @brief 단일 스텝 CBF 투영 (ShieldMPPI의 projectControlCBF와 유사)
+   * @param state 현재 상태 (nx,)
+   * @param u 제어 입력 (nu,)
+   * @param model 동역학 모델
+   * @param gamma_t 시간 감쇠된 gamma
+   * @return 투영된 제어 (nu,)
+   */
+  Eigen::VectorXd projectStep(
+    const Eigen::VectorXd& state,
+    const Eigen::VectorXd& u,
+    const MotionModel& model,
+    double gamma_t) const;
+
+  /** @brief 단일 상태 동역학: f(x, u) -> x_dot */
+  Eigen::VectorXd computeXdot(
+    const Eigen::VectorXd& state,
+    const Eigen::VectorXd& u,
+    const MotionModel& model) const;
+
+  /** @brief 제어 입력 클리핑 */
+  Eigen::VectorXd clipControl(const Eigen::VectorXd& u) const;
+
+  BarrierFunctionSet* barrier_set_;
+  double gamma_;
+  double dt_;
+  Eigen::VectorXd u_min_;
+  Eigen::VectorXd u_max_;
+  int max_iterations_{10};
+  double horizon_decay_{1.0};  // gamma_t = gamma * decay^t (1.0 = 균일)
+  double step_size_{0.1};      // projected gradient step size
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__PREDICTIVE_SAFETY_FILTER_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/predictive_safety_mppi_controller_plugin.hpp
+++ b/ros2_ws/src/mpc_controller_ros2/include/mpc_controller_ros2/predictive_safety_mppi_controller_plugin.hpp
@@ -1,0 +1,59 @@
+#ifndef MPC_CONTROLLER_ROS2__PREDICTIVE_SAFETY_MPPI_CONTROLLER_PLUGIN_HPP_
+#define MPC_CONTROLLER_ROS2__PREDICTIVE_SAFETY_MPPI_CONTROLLER_PLUGIN_HPP_
+
+#include "mpc_controller_ros2/shield_mppi_controller_plugin.hpp"
+#include "mpc_controller_ros2/predictive_safety_filter.hpp"
+#include <memory>
+
+namespace mpc_controller_ros2
+{
+
+/**
+ * @brief Predictive Safety MPPI Controller Plugin
+ *
+ * ShieldMPPI를 상속하여 N-step 예측 안전 필터를 추가합니다.
+ *
+ * ShieldMPPI와의 차이:
+ *   - ShieldMPPI: 최적 u* 첫 스텝만 CBF 투영
+ *   - PredictiveSafety: 전체 horizon N스텝 forward rollout + CBF 투영
+ *   → recursive feasibility 보장
+ *
+ * 파이프라인:
+ *   1. MPPI 샘플링 → optimal u* sequence (부모 MPPIControllerPlugin)
+ *   2. Shield CBF per-step 투영 (부모 ShieldMPPIControllerPlugin)
+ *   3. N-step Predictive Safety Filter (이 클래스)
+ *
+ * 파라미터:
+ *   predictive_safety_enabled: true/false
+ *   predictive_safety_horizon: N (투영 horizon, 기본=전체)
+ *   predictive_safety_decay: γ 감쇠 (기본 1.0=균일)
+ *   predictive_safety_max_iterations: 스텝당 최대 투영 반복
+ */
+class PredictiveSafetyMPPIControllerPlugin : public ShieldMPPIControllerPlugin
+{
+public:
+  PredictiveSafetyMPPIControllerPlugin() = default;
+  ~PredictiveSafetyMPPIControllerPlugin() override = default;
+
+  void configure(
+    const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent,
+    std::string name,
+    std::shared_ptr<tf2_ros::Buffer> tf,
+    std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros
+  ) override;
+
+protected:
+  std::pair<Eigen::VectorXd, MPPIInfo> computeControl(
+    const Eigen::VectorXd& current_state,
+    const Eigen::MatrixXd& reference_trajectory
+  ) override;
+
+private:
+  std::unique_ptr<PredictiveSafetyFilter> predictive_filter_;
+  bool predictive_safety_enabled_{false};
+  int predictive_safety_horizon_{0};  // 0 = 전체 horizon
+};
+
+}  // namespace mpc_controller_ros2
+
+#endif  // MPC_CONTROLLER_ROS2__PREDICTIVE_SAFETY_MPPI_CONTROLLER_PLUGIN_HPP_

--- a/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
+++ b/ros2_ws/src/mpc_controller_ros2/launch/mppi_ros2_control_nav2.launch.py
@@ -176,6 +176,8 @@ def launch_setup(context, *args, **kwargs):
                             'Adaptive Shield-MPPI (distance/velocity adaptive CBF)'),
         'clf_cbf': ('nav2_params_clf_cbf_mppi.yaml',
                     'CLF-CBF-MPPI (unified CLF+CBF QP safety filter)'),
+        'predictive_safety': ('nav2_params_predictive_safety_mppi.yaml',
+                              'Predictive Safety MPPI (N-step CBF projection)'),
     }
     if controller_type in controller_map:
         params_name, controller_label = controller_map[controller_type]
@@ -883,7 +885,7 @@ def generate_launch_description():
             default_value='swerve',
             description='MPPI controller type: "custom", "log", "tsallis", "risk_aware", '
                         '"svmpc", "smooth", "spline", "svg", "biased", "swerve", '
-                        '"non_coaxial", "non_coaxial_60deg", "ackermann", "shield", "adaptive_shield", "clf_cbf", "stress_test", or "nav2"'
+                        '"non_coaxial", "non_coaxial_60deg", "ackermann", "shield", "adaptive_shield", "clf_cbf", "predictive_safety", "stress_test", or "nav2"'
         ),
         DeclareLaunchArgument(
             'headless',

--- a/ros2_ws/src/mpc_controller_ros2/plugins/mppi_controller_plugin.xml
+++ b/ros2_ws/src/mpc_controller_ros2/plugins/mppi_controller_plugin.xml
@@ -121,4 +121,11 @@
       Inherits Shield-MPPI per-step projection + CLF-CBF post-filter.
     </description>
   </class>
+  <class type="mpc_controller_ros2::PredictiveSafetyMPPIControllerPlugin" base_class_type="nav2_core::Controller">
+    <description>
+      Predictive Safety MPPI controller plugin for nav2.
+      N-step forward rollout CBF projection for recursive feasibility.
+      Extends Shield-MPPI per-step projection to full horizon safety guarantee.
+    </description>
+  </class>
 </library>

--- a/ros2_ws/src/mpc_controller_ros2/src/barrier_function.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/barrier_function.cpp
@@ -145,4 +145,171 @@ std::vector<const C3BFBarrier*> BarrierFunctionSet::getActiveC3BFBarriers(
   return active;
 }
 
+// ============================================================================
+// CBF 합성 메서드
+// ============================================================================
+
+double BarrierFunctionSet::evaluateComposite(
+  const Eigen::VectorXd& state,
+  CBFCompositionMethod method,
+  double alpha) const
+{
+  auto active = getActiveBarriers(state);
+  if (active.empty()) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  switch (method) {
+    case CBFCompositionMethod::MIN: {
+      double h_min = active[0]->evaluate(state);
+      for (size_t i = 1; i < active.size(); ++i) {
+        h_min = std::min(h_min, active[i]->evaluate(state));
+      }
+      return h_min;
+    }
+
+    case CBFCompositionMethod::SMOOTH_MIN: {
+      // h_c = -(1/α)·log(Σ exp(-α·h_i))
+      // 수치 안정성: max_val 빼기
+      double max_neg = -alpha * active[0]->evaluate(state);
+      for (size_t i = 1; i < active.size(); ++i) {
+        max_neg = std::max(max_neg, -alpha * active[i]->evaluate(state));
+      }
+      double sum_exp = 0.0;
+      for (const auto* b : active) {
+        sum_exp += std::exp(-alpha * b->evaluate(state) - max_neg);
+      }
+      return -(1.0 / alpha) * (std::log(sum_exp) + max_neg);
+    }
+
+    case CBFCompositionMethod::LOG_SUM_EXP: {
+      // α=1 특수 경우: h_c = -log(Σ exp(-h_i))
+      double max_neg = -active[0]->evaluate(state);
+      for (size_t i = 1; i < active.size(); ++i) {
+        max_neg = std::max(max_neg, -active[i]->evaluate(state));
+      }
+      double sum_exp = 0.0;
+      for (const auto* b : active) {
+        sum_exp += std::exp(-b->evaluate(state) - max_neg);
+      }
+      return -(std::log(sum_exp) + max_neg);
+    }
+
+    case CBFCompositionMethod::PRODUCT: {
+      // h_c = Π max(0, h_i)
+      double product = 1.0;
+      for (const auto* b : active) {
+        double h = b->evaluate(state);
+        product *= std::max(0.0, h);
+      }
+      return product;
+    }
+  }
+
+  return 0.0;  // 도달 불가
+}
+
+Eigen::VectorXd BarrierFunctionSet::compositeGradient(
+  const Eigen::VectorXd& state,
+  CBFCompositionMethod method,
+  double alpha) const
+{
+  int nx = state.size();
+  auto active = getActiveBarriers(state);
+  if (active.empty()) {
+    return Eigen::VectorXd::Zero(nx);
+  }
+
+  switch (method) {
+    case CBFCompositionMethod::MIN: {
+      // gradient of min = gradient of argmin barrier
+      int min_idx = 0;
+      double h_min = active[0]->evaluate(state);
+      for (size_t i = 1; i < active.size(); ++i) {
+        double h = active[i]->evaluate(state);
+        if (h < h_min) {
+          h_min = h;
+          min_idx = i;
+        }
+      }
+      return active[min_idx]->gradient(state);
+    }
+
+    case CBFCompositionMethod::SMOOTH_MIN: {
+      // ∇h_c = Σ w_i · ∇h_i, where w_i = exp(-α·h_i) / Σ exp(-α·h_j)
+      // 수치 안정성: max_neg 빼기
+      std::vector<double> h_vals(active.size());
+      double max_neg = -std::numeric_limits<double>::infinity();
+      for (size_t i = 0; i < active.size(); ++i) {
+        h_vals[i] = active[i]->evaluate(state);
+        max_neg = std::max(max_neg, -alpha * h_vals[i]);
+      }
+
+      std::vector<double> exp_vals(active.size());
+      double sum_exp = 0.0;
+      for (size_t i = 0; i < active.size(); ++i) {
+        exp_vals[i] = std::exp(-alpha * h_vals[i] - max_neg);
+        sum_exp += exp_vals[i];
+      }
+
+      Eigen::VectorXd grad = Eigen::VectorXd::Zero(nx);
+      for (size_t i = 0; i < active.size(); ++i) {
+        double w_i = exp_vals[i] / sum_exp;
+        grad += w_i * active[i]->gradient(state);
+      }
+      return grad;
+    }
+
+    case CBFCompositionMethod::LOG_SUM_EXP: {
+      // α=1 특수 경우
+      std::vector<double> h_vals(active.size());
+      double max_neg = -std::numeric_limits<double>::infinity();
+      for (size_t i = 0; i < active.size(); ++i) {
+        h_vals[i] = active[i]->evaluate(state);
+        max_neg = std::max(max_neg, -h_vals[i]);
+      }
+
+      std::vector<double> exp_vals(active.size());
+      double sum_exp = 0.0;
+      for (size_t i = 0; i < active.size(); ++i) {
+        exp_vals[i] = std::exp(-h_vals[i] - max_neg);
+        sum_exp += exp_vals[i];
+      }
+
+      Eigen::VectorXd grad = Eigen::VectorXd::Zero(nx);
+      for (size_t i = 0; i < active.size(); ++i) {
+        double w_i = exp_vals[i] / sum_exp;
+        grad += w_i * active[i]->gradient(state);
+      }
+      return grad;
+    }
+
+    case CBFCompositionMethod::PRODUCT: {
+      // h_c = Π max(0, h_i)
+      // ∇h_c = Σ_i (Π_{j≠i} max(0, h_j)) · ∇h_i
+      std::vector<double> h_vals(active.size());
+      for (size_t i = 0; i < active.size(); ++i) {
+        h_vals[i] = std::max(0.0, active[i]->evaluate(state));
+      }
+
+      Eigen::VectorXd grad = Eigen::VectorXd::Zero(nx);
+      for (size_t i = 0; i < active.size(); ++i) {
+        double prod_others = 1.0;
+        for (size_t j = 0; j < active.size(); ++j) {
+          if (j != i) {
+            prod_others *= h_vals[j];
+          }
+        }
+        // max(0, h_i) = 0 이면 gradient도 0
+        if (active[i]->evaluate(state) > 0.0) {
+          grad += prod_others * active[i]->gradient(state);
+        }
+      }
+      return grad;
+    }
+  }
+
+  return Eigen::VectorXd::Zero(nx);
+}
+
 }  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/src/clf_cbf_qp_solver.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/clf_cbf_qp_solver.cpp
@@ -215,6 +215,125 @@ CLFCBFQPResult CLFCBFQPSolver::solve(
   return result;
 }
 
+CLFCBFQPResult CLFCBFQPSolver::solveComposite(
+  const Eigen::VectorXd& state,
+  const Eigen::VectorXd& x_des,
+  const Eigen::VectorXd& u_ref,
+  const BatchDynamicsWrapper& dynamics,
+  CBFCompositionMethod method,
+  double composition_alpha) const
+{
+  CLFCBFQPResult result;
+  int nu = u_ref.size();
+
+  // CLF 값 계산
+  result.clf_value = clf_->evaluate(state, x_des);
+
+  // 활성 barrier 확인 — 없으면 CLF only로 대체
+  auto active_barriers = barrier_set_->getActiveBarriers(state);
+  if (active_barriers.empty()) {
+    return solveCLFOnly(state, x_des, u_ref, dynamics);
+  }
+
+  // 초기 해: u_ref
+  Eigen::VectorXd u = clipToBounds(u_ref);
+  double delta = 0.0;  // CLF slack
+
+  for (int iter = 0; iter < kMaxIterations; ++iter) {
+    result.iterations = iter + 1;
+
+    // 동역학 계산
+    Eigen::VectorXd x_dot = computeXdot(state, u, dynamics);
+    Eigen::MatrixXd B = computeB(state, u, x_dot, dynamics);
+
+    // === CLF 제약: V̇ + c·V ≤ δ ===
+    Eigen::VectorXd grad_V = clf_->gradient(state, x_des);
+    double V_dot = grad_V.dot(x_dot);
+    double clf_margin = V_dot + clf_->c() * result.clf_value - delta;
+    Eigen::VectorXd dVdot_du = B.transpose() * grad_V;
+
+    // === 합성 CBF 제약: ḣ_c + γ·h_c ≥ 0 ===
+    double h_c = barrier_set_->evaluateComposite(state, method, composition_alpha);
+    Eigen::VectorXd grad_h_c = barrier_set_->compositeGradient(state, method, composition_alpha);
+    double h_c_dot = grad_h_c.dot(x_dot);
+    double cbf_composite_margin = h_c_dot + gamma_ * h_c;
+
+    bool cbf_satisfied = (cbf_composite_margin >= -kTolerance);
+    bool clf_satisfied = (clf_margin <= kTolerance);
+
+    // === 통합 업데이트 ===
+    if (cbf_satisfied && clf_satisfied) {
+      // 모든 제약 만족 — 목적함수(u_ref에 가깝게) 방향 step
+      Eigen::VectorXd grad_obj = u - u_ref;
+      Eigen::VectorXd u_candidate = u - kStepSize * grad_obj;
+      double delta_candidate = delta * (1.0 - kStepSize);
+      u_candidate = clipToBounds(u_candidate);
+
+      // 제약 유지 확인
+      Eigen::VectorXd x_dot_cand = computeXdot(state, u_candidate, dynamics);
+      double V_dot_cand = grad_V.dot(x_dot_cand);
+      bool still_clf_ok = (V_dot_cand + clf_->c() * result.clf_value - delta_candidate <= kTolerance);
+
+      double h_c_dot_cand = grad_h_c.dot(x_dot_cand);
+      bool still_cbf_ok = (h_c_dot_cand + gamma_ * h_c >= -kTolerance);
+
+      if (still_clf_ok && still_cbf_ok) {
+        u = u_candidate;
+        delta = delta_candidate;
+      }
+      break;  // 수렴
+    }
+
+    // CBF 보정 우선 (안전 > 수렴)
+    if (!cbf_satisfied) {
+      Eigen::VectorXd dhdot_du = B.transpose() * grad_h_c.head(std::min((int)grad_h_c.size(), (int)B.rows()));
+      double norm_sq = dhdot_du.squaredNorm();
+      if (norm_sq > 1e-10) {
+        double correction_scale = (-cbf_composite_margin) / norm_sq;
+        u = u + correction_scale * dhdot_du;
+        u = clipToBounds(u);
+      }
+      // CLF-CBF 충돌 시 slack 증가
+      if (!clf_satisfied) {
+        delta += std::max(0.0, clf_margin);
+      }
+    } else if (!clf_satisfied) {
+      // CBF 만족, CLF만 위반 → CLF 보정
+      double norm_sq = dVdot_du.squaredNorm();
+      if (norm_sq > 1e-10) {
+        double scale = clf_margin / norm_sq;
+        u = u - scale * dVdot_du;
+        u = clipToBounds(u);
+      }
+    }
+  }
+
+  // 최종 결과
+  result.u_safe = u;
+  result.slack = delta;
+  result.feasible = true;
+
+  // 최종 제약 확인
+  Eigen::VectorXd final_xdot = computeXdot(state, u, dynamics);
+  Eigen::VectorXd final_grad_V = clf_->gradient(state, x_des);
+  result.clf_constraint = final_grad_V.dot(final_xdot) +
+    clf_->c() * result.clf_value - delta;
+
+  // 합성 CBF 마진 (단일 값)
+  double final_h_c = barrier_set_->evaluateComposite(state, method, composition_alpha);
+  Eigen::VectorXd final_grad_h_c = barrier_set_->compositeGradient(state, method, composition_alpha);
+  double final_h_c_dot = final_grad_h_c.dot(final_xdot);
+  result.cbf_margins.clear();
+  result.cbf_margins.push_back(final_h_c_dot + gamma_ * final_h_c);
+
+  // feasibility 확인
+  if (result.cbf_margins[0] < -kTolerance * 10) {
+    result.feasible = false;
+  }
+
+  return result;
+}
+
 CLFCBFQPResult CLFCBFQPSolver::solveCLFOnly(
   const Eigen::VectorXd& state,
   const Eigen::VectorXd& x_des,

--- a/ros2_ws/src/mpc_controller_ros2/src/ensemble_dynamics_model.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/ensemble_dynamics_model.cpp
@@ -1,6 +1,7 @@
 #include "mpc_controller_ros2/ensemble_dynamics_model.hpp"
 #include <stdexcept>
 #include <numeric>
+#include <mutex>
 
 namespace mpc_controller_ros2
 {
@@ -67,7 +68,8 @@ Eigen::MatrixXd EnsembleDynamicsModel::dynamicsBatch(
     return x_dot_nominal;
   }
 
-  // 앙상블 평균 잔차
+  // 앙상블 평균 잔차 (mutex 보호 — 핫스왑 안전)
+  std::lock_guard<std::mutex> lock(ensemble_mutex_);
   Eigen::MatrixXd features = buildFeatures(states, controls);
   int M_models = static_cast<int>(ensemble_.size());
 
@@ -84,6 +86,7 @@ EnsembleDynamicsModel::PredictionResult EnsembleDynamicsModel::predictWithUncert
   const Eigen::MatrixXd& states,
   const Eigen::MatrixXd& controls) const
 {
+  std::lock_guard<std::mutex> lock(ensemble_mutex_);
   Eigen::MatrixXd features = buildFeatures(states, controls);
   int M_models = static_cast<int>(ensemble_.size());
   int M_batch = features.rows();
@@ -111,6 +114,18 @@ EnsembleDynamicsModel::PredictionResult EnsembleDynamicsModel::predictWithUncert
   variance /= static_cast<double>(M_models);
 
   return {mean, variance};
+}
+
+void EnsembleDynamicsModel::updateEnsemble(
+  std::vector<std::unique_ptr<EigenMLP>> new_ensemble)
+{
+  if (new_ensemble.empty()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(ensemble_mutex_);
+  ensemble_ = std::move(new_ensemble);
+  model_version_++;
 }
 
 Eigen::MatrixXd EnsembleDynamicsModel::clipControls(

--- a/ros2_ws/src/mpc_controller_ros2/src/model_reloader.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/model_reloader.cpp
@@ -1,0 +1,98 @@
+#include "mpc_controller_ros2/model_reloader.hpp"
+#include <stdexcept>
+
+namespace mpc_controller_ros2
+{
+
+ModelReloader::ModelReloader(const std::string& weights_dir, int ensemble_size)
+: weights_dir_(weights_dir),
+  ensemble_size_(ensemble_size),
+  last_timestamps_(ensemble_size, std::filesystem::file_time_type::min()),
+  last_reload_time_(std::chrono::steady_clock::time_point::min())
+{
+  if (ensemble_size_ <= 0) {
+    throw std::invalid_argument("ModelReloader: ensemble_size must be > 0");
+  }
+}
+
+std::string ModelReloader::modelPath(int i) const
+{
+  return weights_dir_ + "/model_" + std::to_string(i) + ".bin";
+}
+
+bool ModelReloader::modelsExist() const
+{
+  for (int i = 0; i < ensemble_size_; ++i) {
+    if (!std::filesystem::exists(modelPath(i))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ModelReloader::modelsUpdated() const
+{
+  if (!modelsExist()) {
+    return false;
+  }
+
+  for (int i = 0; i < ensemble_size_; ++i) {
+    auto ts = std::filesystem::last_write_time(modelPath(i));
+    if (ts != last_timestamps_[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ModelReloader::tryReload()
+{
+  if (!modelsExist()) {
+    return false;
+  }
+
+  // 타임스탬프 수집
+  std::vector<std::filesystem::file_time_type> new_timestamps(ensemble_size_);
+  for (int i = 0; i < ensemble_size_; ++i) {
+    new_timestamps[i] = std::filesystem::last_write_time(modelPath(i));
+  }
+
+  // 변경 감지 (최초 로드 포함)
+  bool changed = false;
+  for (int i = 0; i < ensemble_size_; ++i) {
+    if (new_timestamps[i] != last_timestamps_[i]) {
+      changed = true;
+      break;
+    }
+  }
+
+  if (!changed) {
+    return false;
+  }
+
+  // 모델 로드 시도
+  std::vector<std::unique_ptr<EigenMLP>> new_models;
+  new_models.reserve(ensemble_size_);
+
+  try {
+    for (int i = 0; i < ensemble_size_; ++i) {
+      new_models.push_back(EigenMLP::loadFromFile(modelPath(i)));
+    }
+  } catch (const std::exception&) {
+    // 로드 실패 — 이전 상태 유지
+    return false;
+  }
+
+  // 성공: 타임스탬프 갱신 + 모델 저장
+  last_timestamps_ = new_timestamps;
+  loaded_models_ = std::move(new_models);
+  last_reload_time_ = std::chrono::steady_clock::now();
+  return true;
+}
+
+std::vector<std::unique_ptr<EigenMLP>> ModelReloader::takeModels()
+{
+  return std::move(loaded_models_);
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/src/mppi_controller_plugin.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/mppi_controller_plugin.cpp
@@ -1418,6 +1418,10 @@ void MPPIControllerPlugin::declareParameters()
   node_->declare_parameter(prefix + "online_data_capacity", params_.online_data_capacity);
   node_->declare_parameter(prefix + "online_data_export_path", params_.online_data_export_path);
 
+  // Online Learning (Model Reload)
+  node_->declare_parameter(prefix + "model_reload_enabled", params_.model_reload_enabled);
+  node_->declare_parameter(prefix + "model_reload_interval_sec", params_.model_reload_interval_sec);
+
   // Safety Enhancement: BR-MPPI
   node_->declare_parameter(prefix + "barrier_rate_cost_weight", params_.barrier_rate_cost_weight);
 
@@ -1439,6 +1443,17 @@ void MPPIControllerPlugin::declareParameters()
   node_->declare_parameter(prefix + "clf_decay_rate", params_.clf_decay_rate);
   node_->declare_parameter(prefix + "clf_slack_penalty", params_.clf_slack_penalty);
   node_->declare_parameter(prefix + "clf_P_scale", params_.clf_P_scale);
+
+  // CBF 합성
+  node_->declare_parameter(prefix + "cbf_composition_enabled", params_.cbf_composition_enabled);
+  node_->declare_parameter(prefix + "cbf_composition_method", params_.cbf_composition_method);
+  node_->declare_parameter(prefix + "cbf_composition_alpha", params_.cbf_composition_alpha);
+
+  // Predictive Safety Filter
+  node_->declare_parameter(prefix + "predictive_safety_enabled", params_.predictive_safety_enabled);
+  node_->declare_parameter(prefix + "predictive_safety_horizon", params_.predictive_safety_horizon);
+  node_->declare_parameter(prefix + "predictive_safety_decay", params_.predictive_safety_decay);
+  node_->declare_parameter(prefix + "predictive_safety_max_iterations", params_.predictive_safety_max_iterations);
 
   // Covariance Steering MPPI (CS-MPPI)
   node_->declare_parameter(prefix + "cs_enabled", params_.cs_enabled);
@@ -1733,6 +1748,10 @@ void MPPIControllerPlugin::loadParameters()
   params_.online_data_capacity = node_->get_parameter(prefix + "online_data_capacity").as_int();
   params_.online_data_export_path = node_->get_parameter(prefix + "online_data_export_path").as_string();
 
+  // Online Learning (Model Reload)
+  params_.model_reload_enabled = node_->get_parameter(prefix + "model_reload_enabled").as_bool();
+  params_.model_reload_interval_sec = node_->get_parameter(prefix + "model_reload_interval_sec").as_double();
+
   // Safety Enhancement: BR-MPPI
   params_.barrier_rate_cost_weight = node_->get_parameter(prefix + "barrier_rate_cost_weight").as_double();
 
@@ -1754,6 +1773,17 @@ void MPPIControllerPlugin::loadParameters()
   params_.clf_decay_rate = node_->get_parameter(prefix + "clf_decay_rate").as_double();
   params_.clf_slack_penalty = node_->get_parameter(prefix + "clf_slack_penalty").as_double();
   params_.clf_P_scale = node_->get_parameter(prefix + "clf_P_scale").as_double();
+
+  // CBF 합성
+  params_.cbf_composition_enabled = node_->get_parameter(prefix + "cbf_composition_enabled").as_bool();
+  params_.cbf_composition_method = node_->get_parameter(prefix + "cbf_composition_method").as_int();
+  params_.cbf_composition_alpha = node_->get_parameter(prefix + "cbf_composition_alpha").as_double();
+
+  // Predictive Safety Filter
+  params_.predictive_safety_enabled = node_->get_parameter(prefix + "predictive_safety_enabled").as_bool();
+  params_.predictive_safety_horizon = node_->get_parameter(prefix + "predictive_safety_horizon").as_int();
+  params_.predictive_safety_decay = node_->get_parameter(prefix + "predictive_safety_decay").as_double();
+  params_.predictive_safety_max_iterations = node_->get_parameter(prefix + "predictive_safety_max_iterations").as_int();
 
   // Covariance Steering MPPI (CS-MPPI)
   params_.cs_enabled = node_->get_parameter(prefix + "cs_enabled").as_bool();

--- a/ros2_ws/src/mpc_controller_ros2/src/online_data_collector.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/online_data_collector.cpp
@@ -1,0 +1,47 @@
+#include "mpc_controller_ros2/online_data_collector.hpp"
+
+namespace mpc_controller_ros2
+{
+
+OnlineDataCollector::OnlineDataCollector(
+  OnlineDataBuffer* buffer,
+  const MotionModel* model,
+  int state_dim, int control_dim)
+: buffer_(buffer),
+  model_(model),
+  nx_(state_dim),
+  nu_(control_dim)
+{
+}
+
+void OnlineDataCollector::collect(
+  const Eigen::VectorXd& prev_state,
+  const Eigen::VectorXd& prev_control,
+  const Eigen::VectorXd& curr_state,
+  double dt)
+{
+  if (!enabled_) {
+    return;
+  }
+
+  // 차원 검증 (불일치 시 silent skip)
+  if (prev_state.size() != nx_ ||
+      prev_control.size() != nu_ ||
+      curr_state.size() != nx_) {
+    return;
+  }
+
+  buffer_->add(prev_state, prev_control, curr_state, dt);
+  total_collected_++;
+}
+
+OnlineDataCollector::Stats OnlineDataCollector::getStats() const
+{
+  Stats stats;
+  stats.total_collected = total_collected_;
+  stats.buffer_size = buffer_->size();
+  stats.buffer_full = buffer_->full();
+  return stats;
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/src/predictive_safety_filter.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/predictive_safety_filter.cpp
@@ -1,0 +1,204 @@
+#include "mpc_controller_ros2/predictive_safety_filter.hpp"
+#include <algorithm>
+#include <cmath>
+
+namespace mpc_controller_ros2
+{
+
+PredictiveSafetyFilter::PredictiveSafetyFilter(
+  BarrierFunctionSet* barrier_set,
+  double gamma, double dt,
+  const Eigen::VectorXd& u_min,
+  const Eigen::VectorXd& u_max)
+: barrier_set_(barrier_set), gamma_(gamma), dt_(dt),
+  u_min_(u_min), u_max_(u_max)
+{
+}
+
+Eigen::VectorXd PredictiveSafetyFilter::computeXdot(
+  const Eigen::VectorXd& state,
+  const Eigen::VectorXd& u,
+  const MotionModel& model) const
+{
+  // MotionModel::dynamics は (x, u) → x_dot
+  Eigen::MatrixXd states(1, state.size());
+  states.row(0) = state.transpose();
+  Eigen::MatrixXd controls(1, u.size());
+  controls.row(0) = u.transpose();
+  // dynamicsBatch returns (1 x nx)
+  Eigen::MatrixXd xdot_batch = model.dynamicsBatch(states, controls);
+  return xdot_batch.row(0).transpose();
+}
+
+Eigen::VectorXd PredictiveSafetyFilter::clipControl(
+  const Eigen::VectorXd& u) const
+{
+  Eigen::VectorXd clipped = u;
+  for (int i = 0; i < u.size(); ++i) {
+    clipped(i) = std::clamp(clipped(i), u_min_(i), u_max_(i));
+  }
+  return clipped;
+}
+
+Eigen::VectorXd PredictiveSafetyFilter::projectStep(
+  const Eigen::VectorXd& state,
+  const Eigen::VectorXd& u,
+  const MotionModel& model,
+  double gamma_t) const
+{
+  Eigen::VectorXd u_proj = u;
+
+  auto active = barrier_set_->getActiveBarriers(state);
+  if (active.empty()) {
+    return clipControl(u_proj);
+  }
+
+  for (int iter = 0; iter < max_iterations_; ++iter) {
+    Eigen::VectorXd xdot = computeXdot(state, u_proj, model);
+
+    bool all_satisfied = true;
+    for (const auto* barrier : active) {
+      double h = barrier->evaluate(state);
+      Eigen::VectorXd grad_h = barrier->gradient(state);
+      double h_dot = grad_h.dot(xdot);
+      double margin = h_dot + gamma_t * h;
+
+      if (margin < -1e-6) {
+        all_satisfied = false;
+        // Projected gradient: u += step * (∂ḣ/∂u) * violation
+        // ∂ḣ/∂u ≈ ∇h^T · ∂f/∂u (finite difference)
+        int nu = u_proj.size();
+        Eigen::VectorXd dh_du(nu);
+        constexpr double delta = 1e-4;
+        for (int j = 0; j < nu; ++j) {
+          Eigen::VectorXd u_plus = u_proj;
+          u_plus(j) += delta;
+          Eigen::VectorXd xdot_plus = computeXdot(state, u_plus, model);
+          double h_dot_plus = grad_h.dot(xdot_plus);
+          dh_du(j) = (h_dot_plus - h_dot) / delta;
+        }
+
+        double norm_sq = dh_du.squaredNorm();
+        if (norm_sq > 1e-10) {
+          double correction = (-margin) / norm_sq;
+          u_proj = u_proj + correction * dh_du;
+          u_proj = clipControl(u_proj);
+        }
+      }
+    }
+
+    if (all_satisfied) {
+      break;
+    }
+  }
+
+  return clipControl(u_proj);
+}
+
+PredictiveSafetyResult PredictiveSafetyFilter::filter(
+  const Eigen::VectorXd& x0,
+  const Eigen::MatrixXd& control_sequence,
+  const MotionModel& model) const
+{
+  int N = control_sequence.rows();
+  int nu = control_sequence.cols();
+  int nx = x0.size();
+
+  PredictiveSafetyResult result;
+  result.u_safe_sequence = control_sequence;  // (N x nu) 복사
+  result.safe_trajectory = Eigen::MatrixXd::Zero(N + 1, nx);
+  result.safe_trajectory.row(0) = x0.transpose();
+  result.feasible = true;
+  result.num_corrected_steps = 0;
+  result.min_barrier_values.resize(N + 1, std::numeric_limits<double>::infinity());
+
+  Eigen::VectorXd x = x0;
+
+  for (int t = 0; t < N; ++t) {
+    // 시간 감쇠 gamma
+    double gamma_t = gamma_ * std::pow(horizon_decay_, t);
+
+    // 최소 barrier 값 기록
+    auto active = barrier_set_->getActiveBarriers(x);
+    if (!active.empty()) {
+      double min_h = std::numeric_limits<double>::infinity();
+      for (const auto* b : active) {
+        min_h = std::min(min_h, b->evaluate(x));
+      }
+      result.min_barrier_values[t] = min_h;
+    }
+
+    // CBF 투영
+    Eigen::VectorXd u_orig = control_sequence.row(t).transpose();
+    Eigen::VectorXd u_safe = projectStep(x, u_orig, model, gamma_t);
+
+    if ((u_safe - u_orig).norm() > 1e-6) {
+      result.num_corrected_steps++;
+    }
+
+    result.u_safe_sequence.row(t) = u_safe.transpose();
+
+    // Forward rollout with corrected control
+    Eigen::VectorXd xdot = computeXdot(x, u_safe, model);
+    x = x + dt_ * xdot;
+
+    // Normalize angles if needed
+    // normalizeStates expects MatrixXd reference
+    Eigen::MatrixXd x_mat(1, x.size());
+    x_mat.row(0) = x.transpose();
+    model.normalizeStates(x_mat);
+    x = x_mat.row(0).transpose();
+
+    result.safe_trajectory.row(t + 1) = x.transpose();
+  }
+
+  // 마지막 스텝 barrier 값
+  auto final_active = barrier_set_->getActiveBarriers(x);
+  if (!final_active.empty()) {
+    double min_h = std::numeric_limits<double>::infinity();
+    for (const auto* b : final_active) {
+      min_h = std::min(min_h, b->evaluate(x));
+    }
+    result.min_barrier_values[N] = min_h;
+    if (min_h < 0) {
+      result.feasible = false;
+    }
+  }
+
+  return result;
+}
+
+bool PredictiveSafetyFilter::verifyTrajectory(
+  const Eigen::VectorXd& x0,
+  const Eigen::MatrixXd& control_sequence,
+  const MotionModel& model) const
+{
+  int N = control_sequence.rows();
+  Eigen::VectorXd x = x0;
+
+  for (int t = 0; t < N; ++t) {
+    double gamma_t = gamma_ * std::pow(horizon_decay_, t);
+    Eigen::VectorXd u = control_sequence.row(t).transpose();
+    Eigen::VectorXd xdot = computeXdot(x, u, model);
+
+    auto active = barrier_set_->getActiveBarriers(x);
+    for (const auto* barrier : active) {
+      double h = barrier->evaluate(x);
+      double h_dot = barrier->gradient(x).dot(xdot);
+      if (h_dot + gamma_t * h < -1e-6) {
+        return false;
+      }
+    }
+
+    x = x + dt_ * xdot;
+    // normalizeStates expects MatrixXd reference
+    Eigen::MatrixXd x_mat(1, x.size());
+    x_mat.row(0) = x.transpose();
+    model.normalizeStates(x_mat);
+    x = x_mat.row(0).transpose();
+  }
+
+  return true;
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/src/predictive_safety_mppi_controller_plugin.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/src/predictive_safety_mppi_controller_plugin.cpp
@@ -1,0 +1,88 @@
+#include "mpc_controller_ros2/predictive_safety_mppi_controller_plugin.hpp"
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(mpc_controller_ros2::PredictiveSafetyMPPIControllerPlugin, nav2_core::Controller)
+
+namespace mpc_controller_ros2
+{
+
+void PredictiveSafetyMPPIControllerPlugin::configure(
+  const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent,
+  std::string name,
+  std::shared_ptr<tf2_ros::Buffer> tf,
+  std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros)
+{
+  ShieldMPPIControllerPlugin::configure(parent, name, tf, costmap_ros);
+
+  predictive_safety_enabled_ = params_.predictive_safety_enabled;
+  predictive_safety_horizon_ = params_.predictive_safety_horizon;
+
+  if (predictive_safety_enabled_) {
+    int nu = dynamics_->model().controlDim();
+    Eigen::VectorXd u_min(nu), u_max(nu);
+    if (nu >= 2) {
+      u_min(0) = params_.v_min;
+      u_max(0) = params_.v_max;
+      u_min(1) = params_.omega_min;
+      u_max(1) = params_.omega_max;
+    }
+    if (nu >= 3) {
+      u_min(2) = params_.omega_min;
+      u_max(2) = params_.omega_max;
+    }
+
+    predictive_filter_ = std::make_unique<PredictiveSafetyFilter>(
+      &barrier_set_, params_.cbf_gamma, params_.dt,
+      u_min, u_max);
+
+    predictive_filter_->setMaxIterations(params_.predictive_safety_max_iterations);
+    predictive_filter_->setHorizonDecay(params_.predictive_safety_decay);
+
+    RCLCPP_INFO(node_->get_logger(),
+      "Predictive Safety MPPI configured (horizon=%d, decay=%.2f, max_iter=%d)",
+      predictive_safety_horizon_,
+      params_.predictive_safety_decay,
+      params_.predictive_safety_max_iterations);
+  }
+}
+
+std::pair<Eigen::VectorXd, MPPIInfo> PredictiveSafetyMPPIControllerPlugin::computeControl(
+  const Eigen::VectorXd& current_state,
+  const Eigen::MatrixXd& reference_trajectory)
+{
+  // 1. Shield-MPPI (MPPI + per-step CBF)
+  auto [u_opt, info] = ShieldMPPIControllerPlugin::computeControl(
+    current_state, reference_trajectory);
+
+  // 2. Predictive Safety 비활성화 시 반환
+  if (!predictive_safety_enabled_ || !predictive_filter_) {
+    return {u_opt, info};
+  }
+
+  // 3. 최적 제어 시퀀스 추출 (control_sequence_에서)
+  // control_sequence_: (N x nu) from MPPI solver
+  if (control_sequence_.rows() < 2) {
+    return {u_opt, info};
+  }
+
+  int N = control_sequence_.rows();
+  if (predictive_safety_horizon_ > 0 && predictive_safety_horizon_ < N) {
+    N = predictive_safety_horizon_;
+  }
+
+  // N-step forward safety filter
+  Eigen::MatrixXd ctrl_seq = control_sequence_.topRows(N);
+  auto result = predictive_filter_->filter(
+    current_state, ctrl_seq, dynamics_->model());
+
+  // 첫 스텝 제어를 u_opt으로 교체
+  if (result.feasible || result.num_corrected_steps > 0) {
+    u_opt = result.u_safe_sequence.row(0).transpose();
+    // 나머지 시퀀스도 업데이트 (warm-start용)
+    control_sequence_.topRows(N) = result.u_safe_sequence;
+  }
+
+  return {u_opt, info};
+}
+
+}  // namespace mpc_controller_ros2

--- a/ros2_ws/src/mpc_controller_ros2/test/unit/test_cbf_composition.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/test/unit/test_cbf_composition.cpp
@@ -1,0 +1,522 @@
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <cmath>
+#include <memory>
+#include <limits>
+#include <vector>
+
+#include "mpc_controller_ros2/barrier_function.hpp"
+#include "mpc_controller_ros2/clf_cbf_qp_solver.hpp"
+#include "mpc_controller_ros2/clf_function.hpp"
+#include "mpc_controller_ros2/motion_model.hpp"
+#include "mpc_controller_ros2/motion_model_factory.hpp"
+#include "mpc_controller_ros2/batch_dynamics_wrapper.hpp"
+#include "mpc_controller_ros2/mppi_params.hpp"
+
+using namespace mpc_controller_ros2;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+static MPPIParams makeDefaultParams()
+{
+  MPPIParams params;
+  params.motion_model = "diff_drive";
+  params.dt = 0.05;
+  return params;
+}
+
+static std::shared_ptr<MotionModel> makeDiffDriveModel()
+{
+  auto params = makeDefaultParams();
+  return std::shared_ptr<MotionModel>(
+    MotionModelFactory::create("diff_drive", params).release());
+}
+
+// ============================================================================
+// CBFComposition_EvaluateComposite
+// ============================================================================
+
+class CBFCompositionEvaluateTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    barrier_set_ = std::make_unique<BarrierFunctionSet>(0.2, 0.3, 10.0);
+    state_ = Eigen::Vector3d(0.0, 0.0, 0.0);
+  }
+
+  std::unique_ptr<BarrierFunctionSet> barrier_set_;
+  Eigen::VectorXd state_;
+};
+
+// --- 1. SingleBarrier_EqualsOriginal ---
+// 단일 barrier인 경우, 모든 합성 방법이 동일한 값을 반환해야 함
+TEST_F(CBFCompositionEvaluateTest, SingleBarrier_EqualsOriginal)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(2.0, 0.0, 0.3));  // d_safe = 0.3 + 0.2 + 0.3 = 0.8
+  barrier_set_->setObstacles(obs);
+
+  // 개별 barrier 값
+  Eigen::VectorXd all_h = barrier_set_->evaluateAll(state_);
+  ASSERT_EQ(all_h.size(), 1);
+  double h_single = all_h(0);
+
+  // 모든 합성 방법이 동일한 값 반환
+  double h_min = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::MIN);
+  double h_smooth = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::SMOOTH_MIN, 100.0);
+  double h_lse = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::LOG_SUM_EXP);
+  double h_prod = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::PRODUCT);
+
+  EXPECT_NEAR(h_min, h_single, 1e-10)
+    << "MIN: 단일 barrier와 동일해야 함";
+  EXPECT_NEAR(h_smooth, h_single, 0.05)
+    << "SMOOTH_MIN(alpha=100): 단일 barrier에 근사해야 함";
+  EXPECT_NEAR(h_lse, h_single, 0.01)
+    << "LOG_SUM_EXP: 단일 barrier에 근사해야 함";
+  EXPECT_NEAR(h_prod, h_single, 1e-10)
+    << "PRODUCT: 단일 barrier와 동일해야 함";
+}
+
+// --- 2. SmoothMin_ApproximatesMin ---
+// alpha가 클수록 smooth min이 실제 min에 가까워져야 함
+TEST_F(CBFCompositionEvaluateTest, SmoothMin_ApproximatesMin)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(1.5, 0.0, 0.3));   // 가까운 장애물
+  obs.push_back(Eigen::Vector3d(3.0, 1.0, 0.5));    // 먼 장애물
+  obs.push_back(Eigen::Vector3d(2.0, -1.0, 0.2));   // 중간 장애물
+  barrier_set_->setObstacles(obs);
+
+  double h_min = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::MIN);
+  double h_smooth_100 = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::SMOOTH_MIN, 100.0);
+
+  // smooth min은 항상 min 이하 (하한)
+  EXPECT_LE(h_smooth_100, h_min + 1e-6)
+    << "SMOOTH_MIN <= MIN (smooth min은 하한 근사)";
+
+  // alpha=100이면 min과 매우 가까워야 함
+  EXPECT_NEAR(h_smooth_100, h_min, 0.1)
+    << "alpha=100: SMOOTH_MIN이 MIN에 가까워야 함";
+
+  // alpha가 작으면 min과 더 멀어짐
+  double h_smooth_1 = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::SMOOTH_MIN, 1.0);
+  double diff_100 = std::abs(h_smooth_100 - h_min);
+  double diff_1 = std::abs(h_smooth_1 - h_min);
+  EXPECT_LE(diff_100, diff_1 + 1e-6)
+    << "alpha가 클수록 min에 더 가까움";
+}
+
+// --- 3. LogSumExp_AlphaOneCase ---
+// LOG_SUM_EXP는 alpha=1인 smooth min과 동일
+TEST_F(CBFCompositionEvaluateTest, LogSumExp_AlphaOneCase)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(2.0, 0.0, 0.3));
+  obs.push_back(Eigen::Vector3d(3.0, 2.0, 0.4));
+  barrier_set_->setObstacles(obs);
+
+  double h_lse = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::LOG_SUM_EXP);
+  double h_smooth_alpha1 = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::SMOOTH_MIN, 1.0);
+
+  EXPECT_NEAR(h_lse, h_smooth_alpha1, 1e-8)
+    << "LOG_SUM_EXP == SMOOTH_MIN(alpha=1)";
+}
+
+// --- 4. Product_AllPositive ---
+// 모든 h_i > 0일 때, product = h_1 * h_2 * ...
+TEST_F(CBFCompositionEvaluateTest, Product_AllPositive)
+{
+  // 모든 장애물이 멀어서 h_i > 0
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(3.0, 0.0, 0.3));   // 먼 장애물
+  obs.push_back(Eigen::Vector3d(0.0, 4.0, 0.2));   // 먼 장애물
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd all_h = barrier_set_->evaluateAll(state_);
+  ASSERT_EQ(all_h.size(), 2);
+  EXPECT_GT(all_h(0), 0.0);
+  EXPECT_GT(all_h(1), 0.0);
+
+  double expected_product = all_h(0) * all_h(1);
+  double h_prod = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::PRODUCT);
+
+  EXPECT_NEAR(h_prod, expected_product, 1e-8)
+    << "PRODUCT: h_1 * h_2";
+  EXPECT_GT(h_prod, 0.0)
+    << "모든 h > 0이면 product > 0";
+}
+
+// --- 5. Product_OneNegative_ZeroProduct ---
+// h_i 중 하나가 음수이면 product가 0으로 클램프되거나 부호가 바뀜
+TEST_F(CBFCompositionEvaluateTest, Product_OneNegative_ZeroProduct)
+{
+  // 장애물 내부에 위치 (h < 0)
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(0.3, 0.0, 0.3));   // 매우 가까움 → h < 0
+  obs.push_back(Eigen::Vector3d(5.0, 0.0, 0.2));   // 멀리 → h > 0
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd all_h = barrier_set_->evaluateAll(state_);
+  ASSERT_EQ(all_h.size(), 2);
+  EXPECT_LT(all_h(0), 0.0) << "첫 번째 barrier는 음수 (장애물 내부)";
+  EXPECT_GT(all_h(1), 0.0) << "두 번째 barrier는 양수 (안전 영역)";
+
+  double h_prod = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::PRODUCT);
+
+  // product = 음수 * 양수 → 음수 또는 0 클램프
+  // 핵심: h < 0인 barrier가 있으면 product가 안전하지 않음을 반영
+  EXPECT_LE(h_prod, 0.0)
+    << "음수 barrier가 있으면 product <= 0";
+}
+
+// --- 6. NoActiveBarriers_ReturnsInfinity ---
+// 활성 barrier가 없으면 무한대(또는 매우 큰 양수) 반환
+TEST_F(CBFCompositionEvaluateTest, NoActiveBarriers_ReturnsInfinity)
+{
+  // 장애물 설정하지 않음 (empty)
+  double h_min = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::MIN);
+  double h_smooth = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::SMOOTH_MIN);
+  double h_lse = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::LOG_SUM_EXP);
+  double h_prod = barrier_set_->evaluateComposite(
+    state_, CBFCompositionMethod::PRODUCT);
+
+  // 장애물 없음 → 무한대 또는 매우 큰 양수
+  double large_val = 1e6;
+  EXPECT_GT(h_min, large_val)
+    << "barrier 없으면 infinity 또는 매우 큰 값";
+  EXPECT_GT(h_smooth, large_val);
+  EXPECT_GT(h_lse, large_val);
+  EXPECT_GT(h_prod, large_val);
+}
+
+// ============================================================================
+// CBFComposition_CompositeGradient
+// ============================================================================
+
+class CBFCompositionGradientTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    barrier_set_ = std::make_unique<BarrierFunctionSet>(0.2, 0.3, 10.0);
+    state_ = Eigen::Vector3d(0.0, 0.0, 0.0);
+  }
+
+  std::unique_ptr<BarrierFunctionSet> barrier_set_;
+  Eigen::VectorXd state_;
+};
+
+// --- 7. SingleBarrier_EqualsGradient ---
+// 단일 barrier gradient와 합성 gradient가 동일
+TEST_F(CBFCompositionGradientTest, SingleBarrier_EqualsGradient)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(2.0, 1.0, 0.3));
+  barrier_set_->setObstacles(obs);
+
+  // 개별 gradient
+  const auto& barriers = barrier_set_->barriers();
+  ASSERT_EQ(barriers.size(), 1u);
+  Eigen::VectorXd grad_single = barriers[0].gradient(state_);
+
+  // 합성 gradient (모든 방법)
+  Eigen::VectorXd grad_min = barrier_set_->compositeGradient(
+    state_, CBFCompositionMethod::MIN);
+  Eigen::VectorXd grad_prod = barrier_set_->compositeGradient(
+    state_, CBFCompositionMethod::PRODUCT);
+
+  ASSERT_EQ(grad_min.size(), state_.size());
+  ASSERT_EQ(grad_prod.size(), state_.size());
+
+  for (int i = 0; i < state_.size(); ++i) {
+    EXPECT_NEAR(grad_min(i), grad_single(i), 1e-8)
+      << "MIN gradient[" << i << "]";
+    EXPECT_NEAR(grad_prod(i), grad_single(i), 1e-8)
+      << "PRODUCT gradient[" << i << "]";
+  }
+}
+
+// --- 8. SmoothMin_WeightedAverage ---
+// smooth min gradient는 softmax 가중 평균이고, 가중치 합 = 1
+TEST_F(CBFCompositionGradientTest, SmoothMin_WeightedAverage)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(2.0, 0.0, 0.3));
+  obs.push_back(Eigen::Vector3d(0.0, 3.0, 0.4));
+  barrier_set_->setObstacles(obs);
+
+  double alpha = 10.0;
+  Eigen::VectorXd grad_smooth = barrier_set_->compositeGradient(
+    state_, CBFCompositionMethod::SMOOTH_MIN, alpha);
+
+  ASSERT_EQ(grad_smooth.size(), state_.size());
+
+  // gradient는 0이 아니어야 함 (장애물이 있으므로)
+  EXPECT_GT(grad_smooth.norm(), 1e-10)
+    << "합성 gradient는 비영벡터여야 함";
+
+  // 유한차분 검증: ∂h_c/∂x_i ≈ (h_c(x+eps*e_i) - h_c(x-eps*e_i)) / (2*eps)
+  double eps = 1e-5;
+  for (int i = 0; i < state_.size(); ++i) {
+    Eigen::VectorXd state_plus = state_;
+    Eigen::VectorXd state_minus = state_;
+    state_plus(i) += eps;
+    state_minus(i) -= eps;
+
+    double h_plus = barrier_set_->evaluateComposite(
+      state_plus, CBFCompositionMethod::SMOOTH_MIN, alpha);
+    double h_minus = barrier_set_->evaluateComposite(
+      state_minus, CBFCompositionMethod::SMOOTH_MIN, alpha);
+    double fd = (h_plus - h_minus) / (2.0 * eps);
+
+    EXPECT_NEAR(grad_smooth(i), fd, 1e-3)
+      << "SMOOTH_MIN gradient[" << i << "] 유한차분 검증";
+  }
+}
+
+// --- 9. Min_ArgminGradient ---
+// MIN 방법의 gradient는 argmin barrier의 gradient와 동일
+TEST_F(CBFCompositionGradientTest, Min_ArgminGradient)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(1.5, 0.0, 0.3));   // 가까움 (h 작음)
+  obs.push_back(Eigen::Vector3d(5.0, 0.0, 0.2));   // 멀리 (h 큼)
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd all_h = barrier_set_->evaluateAll(state_);
+  ASSERT_EQ(all_h.size(), 2);
+
+  // argmin 찾기
+  int argmin_idx = 0;
+  if (all_h(1) < all_h(0)) argmin_idx = 1;
+
+  Eigen::VectorXd grad_argmin = barrier_set_->barriers()[argmin_idx].gradient(state_);
+  Eigen::VectorXd grad_min = barrier_set_->compositeGradient(
+    state_, CBFCompositionMethod::MIN);
+
+  ASSERT_EQ(grad_min.size(), state_.size());
+  for (int i = 0; i < state_.size(); ++i) {
+    EXPECT_NEAR(grad_min(i), grad_argmin(i), 1e-8)
+      << "MIN gradient[" << i << "]는 argmin barrier의 gradient";
+  }
+}
+
+// --- 10. Product_ChainRule ---
+// product gradient = sum_i (prod_{j!=i} h_j) * grad(h_i) (chain rule)
+TEST_F(CBFCompositionGradientTest, Product_ChainRule)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(3.0, 0.0, 0.3));   // h_0 > 0
+  obs.push_back(Eigen::Vector3d(0.0, 4.0, 0.2));   // h_1 > 0
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd all_h = barrier_set_->evaluateAll(state_);
+  ASSERT_EQ(all_h.size(), 2);
+  EXPECT_GT(all_h(0), 0.0);
+  EXPECT_GT(all_h(1), 0.0);
+
+  const auto& barriers = barrier_set_->barriers();
+  Eigen::VectorXd g0 = barriers[0].gradient(state_);
+  Eigen::VectorXd g1 = barriers[1].gradient(state_);
+
+  // chain rule: grad(h0*h1) = h1*grad(h0) + h0*grad(h1)
+  Eigen::VectorXd expected_grad = all_h(1) * g0 + all_h(0) * g1;
+
+  Eigen::VectorXd grad_prod = barrier_set_->compositeGradient(
+    state_, CBFCompositionMethod::PRODUCT);
+
+  ASSERT_EQ(grad_prod.size(), state_.size());
+  for (int i = 0; i < state_.size(); ++i) {
+    EXPECT_NEAR(grad_prod(i), expected_grad(i), 1e-6)
+      << "PRODUCT gradient[" << i << "] chain rule 검증";
+  }
+}
+
+// ============================================================================
+// CBFComposition_SolveComposite
+// ============================================================================
+
+class CBFCompositionSolveTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    model_ = makeDiffDriveModel();
+    MPPIParams params = makeDefaultParams();
+    dynamics_ = std::make_unique<BatchDynamicsWrapper>(params, model_);
+
+    Eigen::MatrixXd P = Eigen::Matrix3d::Identity() * 5.0;
+    clf_ = std::make_unique<CLFFunction>(P, 1.0, std::vector<int>{2});
+
+    barrier_set_ = std::make_unique<BarrierFunctionSet>(0.2, 0.3, 5.0);
+
+    Eigen::VectorXd u_min(2), u_max(2);
+    u_min << -0.5, -1.5;
+    u_max << 0.5, 1.5;
+
+    solver_ = std::make_unique<CLFCBFQPSolver>(
+      clf_.get(), barrier_set_.get(), 1.0, 100.0, u_min, u_max);
+  }
+
+  std::shared_ptr<MotionModel> model_;
+  std::unique_ptr<BatchDynamicsWrapper> dynamics_;
+  std::unique_ptr<CLFFunction> clf_;
+  std::unique_ptr<BarrierFunctionSet> barrier_set_;
+  std::unique_ptr<CLFCBFQPSolver> solver_;
+};
+
+// --- 11. NoBarriers_FallsBackToCLFOnly ---
+// 장애물이 없으면 CLF-only와 동일한 결과
+TEST_F(CBFCompositionSolveTest, NoBarriers_FallsBackToCLFOnly)
+{
+  Eigen::VectorXd state = Eigen::Vector3d(1.0, 0.5, 0.0);
+  Eigen::VectorXd x_des = Eigen::Vector3d(0.0, 0.0, 0.0);
+  Eigen::VectorXd u_ref = Eigen::Vector2d(0.0, 0.0);
+
+  auto result_composite = solver_->solveComposite(
+    state, x_des, u_ref, *dynamics_, CBFCompositionMethod::SMOOTH_MIN);
+  auto result_clf = solver_->solveCLFOnly(
+    state, x_des, u_ref, *dynamics_);
+
+  EXPECT_TRUE(result_composite.feasible)
+    << "장애물 없으면 실현 가능";
+  EXPECT_TRUE(result_clf.feasible);
+
+  // CLF 값은 동일해야 함
+  EXPECT_NEAR(result_composite.clf_value, result_clf.clf_value, 1e-8);
+
+  // 제어 출력도 매우 유사해야 함
+  EXPECT_NEAR(result_composite.u_safe(0), result_clf.u_safe(0), 0.05)
+    << "장애물 없으면 CLF-only와 유사한 결과";
+  EXPECT_NEAR(result_composite.u_safe(1), result_clf.u_safe(1), 0.05);
+}
+
+// --- 12. SingleBarrier_SameAsSolve ---
+// 단일 barrier인 경우, solveComposite가 solve와 유사한 결과
+TEST_F(CBFCompositionSolveTest, SingleBarrier_SameAsSolve)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(2.0, 0.0, 0.1));
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd state = Eigen::Vector3d(0.0, 0.0, 0.0);
+  Eigen::VectorXd x_des = Eigen::Vector3d(3.0, 0.0, 0.0);
+  Eigen::VectorXd u_ref = Eigen::Vector2d(0.3, 0.0);
+
+  auto result_solve = solver_->solve(
+    state, x_des, u_ref, *dynamics_);
+  auto result_composite = solver_->solveComposite(
+    state, x_des, u_ref, *dynamics_, CBFCompositionMethod::SMOOTH_MIN, 100.0);
+
+  // 둘 다 feasible이거나, 아니면 제어 크기가 유사
+  if (result_solve.feasible && result_composite.feasible) {
+    EXPECT_NEAR(result_composite.u_safe(0), result_solve.u_safe(0), 0.3)
+      << "단일 barrier: solveComposite ~ solve";
+  }
+  // 최소한 하나는 결과를 반환
+  EXPECT_EQ(result_composite.u_safe.size(), 2);
+}
+
+// --- 13. MultipleBarriers_Feasible ---
+// 여러 장애물이 있어도 QP가 feasible
+TEST_F(CBFCompositionSolveTest, MultipleBarriers_Feasible)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(3.0, 1.0, 0.2));
+  obs.push_back(Eigen::Vector3d(3.0, -1.0, 0.2));
+  obs.push_back(Eigen::Vector3d(4.0, 0.0, 0.3));
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd state = Eigen::Vector3d(0.0, 0.0, 0.0);
+  Eigen::VectorXd x_des = Eigen::Vector3d(5.0, 0.0, 0.0);
+  Eigen::VectorXd u_ref = Eigen::Vector2d(0.3, 0.0);
+
+  for (auto method : {CBFCompositionMethod::MIN,
+                      CBFCompositionMethod::SMOOTH_MIN,
+                      CBFCompositionMethod::LOG_SUM_EXP,
+                      CBFCompositionMethod::PRODUCT}) {
+    auto result = solver_->solveComposite(
+      state, x_des, u_ref, *dynamics_, method);
+
+    // 원거리 장애물 → feasible해야 함
+    EXPECT_TRUE(result.feasible)
+      << "원거리 다중 장애물에서 QP는 feasible이어야 함";
+    EXPECT_EQ(result.u_safe.size(), 2);
+
+    // 제어 범위 확인
+    EXPECT_GE(result.u_safe(0), -0.5 - 1e-6);
+    EXPECT_LE(result.u_safe(0), 0.5 + 1e-6);
+    EXPECT_GE(result.u_safe(1), -1.5 - 1e-6);
+    EXPECT_LE(result.u_safe(1), 1.5 + 1e-6);
+  }
+}
+
+// --- 14. MultipleBarriers_SafetyMaintained ---
+// 합성 CBF margin이 안전 임계값 이상
+TEST_F(CBFCompositionSolveTest, MultipleBarriers_SafetyMaintained)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(2.5, 0.5, 0.1));
+  obs.push_back(Eigen::Vector3d(2.5, -0.5, 0.1));
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd state = Eigen::Vector3d(0.0, 0.0, 0.0);
+  Eigen::VectorXd x_des = Eigen::Vector3d(4.0, 0.0, 0.0);
+  Eigen::VectorXd u_ref = Eigen::Vector2d(0.3, 0.0);
+
+  auto result = solver_->solveComposite(
+    state, x_des, u_ref, *dynamics_, CBFCompositionMethod::SMOOTH_MIN);
+
+  EXPECT_TRUE(result.feasible);
+
+  // cbf_margins는 합성 CBF의 단일 마진
+  double tolerance = 0.2;  // projected gradient 수렴 허용 오차
+  if (!result.cbf_margins.empty()) {
+    EXPECT_GE(result.cbf_margins[0], -tolerance)
+      << "합성 CBF margin >= -tolerance: 안전 제약 만족";
+  }
+}
+
+// --- 15. MethodComparison ---
+// SMOOTH_MIN과 MIN이 유사한 결과 (alpha가 크면)
+TEST_F(CBFCompositionSolveTest, MethodComparison)
+{
+  std::vector<Eigen::Vector3d> obs;
+  obs.push_back(Eigen::Vector3d(1.5, 0.0, 0.2));
+  obs.push_back(Eigen::Vector3d(0.0, 2.0, 0.3));
+  barrier_set_->setObstacles(obs);
+
+  Eigen::VectorXd state = Eigen::Vector3d(0.0, 0.0, 0.0);
+  Eigen::VectorXd x_des = Eigen::Vector3d(2.0, 1.0, 0.0);
+  Eigen::VectorXd u_ref = Eigen::Vector2d(0.3, 0.1);
+
+  auto result_min = solver_->solveComposite(
+    state, x_des, u_ref, *dynamics_, CBFCompositionMethod::MIN);
+  auto result_smooth = solver_->solveComposite(
+    state, x_des, u_ref, *dynamics_, CBFCompositionMethod::SMOOTH_MIN, 50.0);
+
+  EXPECT_TRUE(result_min.feasible);
+  EXPECT_TRUE(result_smooth.feasible);
+
+  // alpha가 크면 SMOOTH_MIN ≈ MIN이므로 제어 출력이 유사
+  double u_diff = (result_min.u_safe - result_smooth.u_safe).norm();
+  EXPECT_LT(u_diff, 0.3)
+    << "SMOOTH_MIN(alpha=50) vs MIN: 유사한 제어 출력";
+}

--- a/ros2_ws/src/mpc_controller_ros2/test/unit/test_online_learning.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/test/unit/test_online_learning.cpp
@@ -1,0 +1,367 @@
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <filesystem>
+#include <fstream>
+#include <cmath>
+
+#include "mpc_controller_ros2/online_data_collector.hpp"
+#include "mpc_controller_ros2/model_reloader.hpp"
+#include "mpc_controller_ros2/online_data_buffer.hpp"
+#include "mpc_controller_ros2/ensemble_dynamics_model.hpp"
+#include "mpc_controller_ros2/eigen_mlp.hpp"
+#include "mpc_controller_ros2/motion_model.hpp"
+#include "mpc_controller_ros2/motion_model_factory.hpp"
+#include "mpc_controller_ros2/mppi_params.hpp"
+
+using namespace mpc_controller_ros2;
+namespace fs = std::filesystem;
+
+// =============================================================================
+// Helper: 테스트용 EigenMLP 바이너리 파일 저장
+// =============================================================================
+
+static void saveTestMLPFile(const std::string& path, int in_dim, int out_dim,
+                            int hidden = 16) {
+  std::ofstream file(path, std::ios::binary);
+
+  uint32_t magic = 0x454D4C50;  // "EMLP"
+  uint32_t version = 1;
+  uint32_t n_layers = 2;
+  file.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
+  file.write(reinterpret_cast<const char*>(&version), sizeof(version));
+  file.write(reinterpret_cast<const char*>(&n_layers), sizeof(n_layers));
+
+  // Norm params
+  uint32_t in_d = in_dim, out_d = out_dim;
+  file.write(reinterpret_cast<const char*>(&in_d), sizeof(in_d));
+  file.write(reinterpret_cast<const char*>(&out_d), sizeof(out_d));
+
+  Eigen::VectorXd in_mean = Eigen::VectorXd::Zero(in_dim);
+  Eigen::VectorXd in_std = Eigen::VectorXd::Ones(in_dim);
+  Eigen::VectorXd out_mean = Eigen::VectorXd::Zero(out_dim);
+  Eigen::VectorXd out_std = Eigen::VectorXd::Ones(out_dim);
+
+  file.write(reinterpret_cast<const char*>(in_mean.data()), in_dim * sizeof(double));
+  file.write(reinterpret_cast<const char*>(in_std.data()), in_dim * sizeof(double));
+  file.write(reinterpret_cast<const char*>(out_mean.data()), out_dim * sizeof(double));
+  file.write(reinterpret_cast<const char*>(out_std.data()), out_dim * sizeof(double));
+
+  // Layer 1: hidden x in_dim
+  Eigen::MatrixXd w1 = Eigen::MatrixXd::Random(hidden, in_dim) * 0.1;
+  Eigen::VectorXd b1 = Eigen::VectorXd::Zero(hidden);
+  uint32_t rows1 = hidden, cols1 = in_dim;
+  file.write(reinterpret_cast<const char*>(&rows1), sizeof(rows1));
+  file.write(reinterpret_cast<const char*>(&cols1), sizeof(cols1));
+  file.write(reinterpret_cast<const char*>(w1.data()), hidden * in_dim * sizeof(double));
+  file.write(reinterpret_cast<const char*>(b1.data()), hidden * sizeof(double));
+
+  // Layer 2: out_dim x hidden
+  Eigen::MatrixXd w2 = Eigen::MatrixXd::Random(out_dim, hidden) * 0.01;
+  Eigen::VectorXd b2 = Eigen::VectorXd::Zero(out_dim);
+  uint32_t rows2 = out_dim, cols2 = hidden;
+  file.write(reinterpret_cast<const char*>(&rows2), sizeof(rows2));
+  file.write(reinterpret_cast<const char*>(&cols2), sizeof(cols2));
+  file.write(reinterpret_cast<const char*>(w2.data()), out_dim * hidden * sizeof(double));
+  file.write(reinterpret_cast<const char*>(b2.data()), out_dim * sizeof(double));
+}
+
+// =============================================================================
+// OnlineDataCollector 테스트 Fixture
+// =============================================================================
+
+class OnlineDataCollectorTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    MPPIParams params;
+    model_ = MotionModelFactory::create("diff_drive", params);
+    buffer_ = std::make_unique<OnlineDataBuffer>(100);
+    collector_ = std::make_unique<OnlineDataCollector>(
+      buffer_.get(), model_.get(), 3, 2);
+  }
+
+  std::unique_ptr<MotionModel> model_;
+  std::unique_ptr<OnlineDataBuffer> buffer_;
+  std::unique_ptr<OnlineDataCollector> collector_;
+
+  // DiffDrive: nx=3 [x, y, theta], nu=2 [v, omega]
+  static constexpr int kNx = 3;
+  static constexpr int kNu = 2;
+};
+
+// -----------------------------------------------------------------------------
+// 1. CollectValid: 데이터 추가 후 stats 검증
+// -----------------------------------------------------------------------------
+TEST_F(OnlineDataCollectorTest, CollectValid) {
+  Eigen::VectorXd prev_state = Eigen::VectorXd::Zero(kNx);
+  Eigen::VectorXd prev_control = Eigen::VectorXd::Zero(kNu);
+  Eigen::VectorXd curr_state = Eigen::VectorXd::Ones(kNx) * 0.1;
+  double dt = 0.02;
+
+  collector_->collect(prev_state, prev_control, curr_state, dt);
+
+  auto stats = collector_->getStats();
+  EXPECT_EQ(stats.total_collected, 1u);
+  EXPECT_EQ(stats.buffer_size, 1u);
+  EXPECT_FALSE(stats.buffer_full);
+
+  // 추가 수집
+  collector_->collect(prev_state, prev_control, curr_state, dt);
+  collector_->collect(prev_state, prev_control, curr_state, dt);
+
+  stats = collector_->getStats();
+  EXPECT_EQ(stats.total_collected, 3u);
+  EXPECT_EQ(stats.buffer_size, 3u);
+}
+
+// -----------------------------------------------------------------------------
+// 2. DimensionMismatch_Skipped: 잘못된 차원 -> 무시
+// -----------------------------------------------------------------------------
+TEST_F(OnlineDataCollectorTest, DimensionMismatch_Skipped) {
+  Eigen::VectorXd wrong_state = Eigen::VectorXd::Zero(5);  // nx=3인데 5 전달
+  Eigen::VectorXd prev_control = Eigen::VectorXd::Zero(kNu);
+  Eigen::VectorXd curr_state = Eigen::VectorXd::Zero(kNx);
+  double dt = 0.02;
+
+  // prev_state 차원 불일치
+  collector_->collect(wrong_state, prev_control, curr_state, dt);
+  EXPECT_EQ(collector_->getStats().total_collected, 0u);
+  EXPECT_EQ(buffer_->size(), 0u);
+
+  // prev_control 차원 불일치
+  Eigen::VectorXd prev_state = Eigen::VectorXd::Zero(kNx);
+  Eigen::VectorXd wrong_control = Eigen::VectorXd::Zero(4);  // nu=2인데 4 전달
+  collector_->collect(prev_state, wrong_control, curr_state, dt);
+  EXPECT_EQ(collector_->getStats().total_collected, 0u);
+  EXPECT_EQ(buffer_->size(), 0u);
+
+  // curr_state 차원 불일치
+  Eigen::VectorXd wrong_curr = Eigen::VectorXd::Zero(7);
+  collector_->collect(prev_state, prev_control, wrong_curr, dt);
+  EXPECT_EQ(collector_->getStats().total_collected, 0u);
+  EXPECT_EQ(buffer_->size(), 0u);
+}
+
+// -----------------------------------------------------------------------------
+// 3. Disabled_NoCollection: enabled=false -> 수집 안 함
+// -----------------------------------------------------------------------------
+TEST_F(OnlineDataCollectorTest, Disabled_NoCollection) {
+  collector_->setEnabled(false);
+  EXPECT_FALSE(collector_->isEnabled());
+
+  Eigen::VectorXd state = Eigen::VectorXd::Zero(kNx);
+  Eigen::VectorXd control = Eigen::VectorXd::Zero(kNu);
+
+  collector_->collect(state, control, state, 0.02);
+  collector_->collect(state, control, state, 0.02);
+
+  EXPECT_EQ(collector_->getStats().total_collected, 0u);
+  EXPECT_EQ(buffer_->size(), 0u);
+}
+
+// -----------------------------------------------------------------------------
+// 4. EnableDisableToggle: 토글 후 동작 확인
+// -----------------------------------------------------------------------------
+TEST_F(OnlineDataCollectorTest, EnableDisableToggle) {
+  Eigen::VectorXd state = Eigen::VectorXd::Zero(kNx);
+  Eigen::VectorXd control = Eigen::VectorXd::Zero(kNu);
+
+  // 기본: enabled
+  EXPECT_TRUE(collector_->isEnabled());
+  collector_->collect(state, control, state, 0.02);
+  EXPECT_EQ(collector_->getStats().total_collected, 1u);
+
+  // 비활성화
+  collector_->setEnabled(false);
+  collector_->collect(state, control, state, 0.02);
+  EXPECT_EQ(collector_->getStats().total_collected, 1u);  // 변화 없음
+
+  // 다시 활성화
+  collector_->setEnabled(true);
+  collector_->collect(state, control, state, 0.02);
+  EXPECT_EQ(collector_->getStats().total_collected, 2u);
+}
+
+// -----------------------------------------------------------------------------
+// 5. RingBufferOverflow: 용량 초과 시 링 버퍼 덮어쓰기
+// -----------------------------------------------------------------------------
+TEST_F(OnlineDataCollectorTest, RingBufferOverflow) {
+  // 작은 버퍼로 재생성
+  buffer_ = std::make_unique<OnlineDataBuffer>(5);
+  collector_ = std::make_unique<OnlineDataCollector>(
+    buffer_.get(), model_.get(), kNx, kNu);
+
+  Eigen::VectorXd state = Eigen::VectorXd::Zero(kNx);
+  Eigen::VectorXd control = Eigen::VectorXd::Zero(kNu);
+
+  // 5개 채우기
+  for (int i = 0; i < 5; ++i) {
+    collector_->collect(state, control, state, 0.02);
+  }
+  EXPECT_EQ(buffer_->size(), 5u);
+  EXPECT_TRUE(buffer_->full());
+  EXPECT_TRUE(collector_->getStats().buffer_full);
+
+  // 추가 3개 -> 링 버퍼이므로 size는 5 유지, total은 8
+  for (int i = 0; i < 3; ++i) {
+    collector_->collect(state, control, state, 0.02);
+  }
+  EXPECT_EQ(buffer_->size(), 5u);  // 용량 제한
+  EXPECT_EQ(collector_->getStats().total_collected, 8u);
+  EXPECT_TRUE(buffer_->full());
+}
+
+// -----------------------------------------------------------------------------
+// 6. ThreadSafety_Atomic: enabled_ atomic 플래그 set/get
+// -----------------------------------------------------------------------------
+TEST_F(OnlineDataCollectorTest, ThreadSafety_Atomic) {
+  // atomic 플래그의 기본 동작 검증 (단일 스레드에서 일관성 확인)
+  collector_->setEnabled(true);
+  EXPECT_TRUE(collector_->isEnabled());
+
+  collector_->setEnabled(false);
+  EXPECT_FALSE(collector_->isEnabled());
+
+  collector_->setEnabled(true);
+  EXPECT_TRUE(collector_->isEnabled());
+
+  // 빠른 토글 반복 — atomic이 아닌 경우 데이터 레이스 가능
+  for (int i = 0; i < 1000; ++i) {
+    collector_->setEnabled(i % 2 == 0);
+    bool val = collector_->isEnabled();
+    EXPECT_EQ(val, (i % 2 == 0));
+  }
+}
+
+// =============================================================================
+// ModelReloader 테스트 Fixture
+// =============================================================================
+
+class ModelReloaderTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // mkdtemp 패턴으로 임시 디렉토리 생성
+    std::string tmpl = (fs::temp_directory_path() / "test_model_reload_XXXXXX").string();
+    char* dir = mkdtemp(tmpl.data());
+    ASSERT_NE(dir, nullptr) << "Failed to create temp directory";
+    temp_dir_ = std::string(dir);
+  }
+
+  void TearDown() override {
+    if (!temp_dir_.empty() && fs::exists(temp_dir_)) {
+      fs::remove_all(temp_dir_);
+    }
+  }
+
+  // 앙상블 MLP 파일 생성 (model_0.bin ~ model_{M-1}.bin)
+  void createEnsembleFiles(int ensemble_size, int in_dim = 5,
+                           int out_dim = 3, int hidden = 16) {
+    for (int i = 0; i < ensemble_size; ++i) {
+      std::string path = temp_dir_ + "/model_" + std::to_string(i) + ".bin";
+      saveTestMLPFile(path, in_dim, out_dim, hidden);
+    }
+  }
+
+  std::string temp_dir_;
+
+  // DiffDrive 기준: nx=3, nu=2 -> MLP input=5, output=3
+  static constexpr int kInDim = 5;
+  static constexpr int kOutDim = 3;
+  static constexpr int kDefaultEnsemble = 3;
+};
+
+// -----------------------------------------------------------------------------
+// 7. Construction_ValidEnsembleSize: 정상 생성
+// -----------------------------------------------------------------------------
+TEST_F(ModelReloaderTest, Construction_ValidEnsembleSize) {
+  EXPECT_NO_THROW(ModelReloader reloader(temp_dir_, 3));
+  EXPECT_NO_THROW(ModelReloader reloader(temp_dir_, 1));
+  EXPECT_NO_THROW(ModelReloader reloader(temp_dir_, 10));
+}
+
+// -----------------------------------------------------------------------------
+// 8. InvalidEnsembleSize_Throws: ensemble_size=0 -> 예외
+// -----------------------------------------------------------------------------
+TEST_F(ModelReloaderTest, InvalidEnsembleSize_Throws) {
+  EXPECT_THROW(ModelReloader reloader(temp_dir_, 0), std::invalid_argument);
+}
+
+// -----------------------------------------------------------------------------
+// 9. ModelsNotExist: 파일 없음 -> modelsExist()=false
+// -----------------------------------------------------------------------------
+TEST_F(ModelReloaderTest, ModelsNotExist) {
+  ModelReloader reloader(temp_dir_, kDefaultEnsemble);
+  EXPECT_FALSE(reloader.modelsExist());
+}
+
+// -----------------------------------------------------------------------------
+// 10. ModelsExist_AfterCreation: 파일 생성 후 -> modelsExist()=true
+// -----------------------------------------------------------------------------
+TEST_F(ModelReloaderTest, ModelsExist_AfterCreation) {
+  ModelReloader reloader(temp_dir_, kDefaultEnsemble);
+  EXPECT_FALSE(reloader.modelsExist());
+
+  // 앙상블 파일 생성
+  createEnsembleFiles(kDefaultEnsemble, kInDim, kOutDim);
+
+  EXPECT_TRUE(reloader.modelsExist());
+
+  // 일부만 존재하면 false
+  fs::remove(temp_dir_ + "/model_2.bin");
+  EXPECT_FALSE(reloader.modelsExist());
+}
+
+// -----------------------------------------------------------------------------
+// 11. TryReload_Success: 유효한 .bin 파일 -> tryReload()=true
+// -----------------------------------------------------------------------------
+TEST_F(ModelReloaderTest, TryReload_Success) {
+  createEnsembleFiles(kDefaultEnsemble, kInDim, kOutDim);
+
+  ModelReloader reloader(temp_dir_, kDefaultEnsemble);
+  EXPECT_TRUE(reloader.modelsExist());
+
+  bool loaded = reloader.tryReload();
+  EXPECT_TRUE(loaded);
+
+  // 로드 시간이 기록되었는지 확인
+  auto reload_time = reloader.lastReloadTime();
+  EXPECT_NE(reload_time.time_since_epoch().count(), 0);
+}
+
+// -----------------------------------------------------------------------------
+// 12. TakeModels_TransfersOwnership: 로드 후 takeModels -> M개 모델 반환
+// -----------------------------------------------------------------------------
+TEST_F(ModelReloaderTest, TakeModels_TransfersOwnership) {
+  createEnsembleFiles(kDefaultEnsemble, kInDim, kOutDim);
+
+  ModelReloader reloader(temp_dir_, kDefaultEnsemble);
+  ASSERT_TRUE(reloader.tryReload());
+
+  auto models = reloader.takeModels();
+  EXPECT_EQ(static_cast<int>(models.size()), kDefaultEnsemble);
+
+  // 각 모델이 유효한지 확인
+  for (int i = 0; i < kDefaultEnsemble; ++i) {
+    ASSERT_NE(models[i], nullptr);
+    EXPECT_EQ(models[i]->inputDim(), kInDim);
+    EXPECT_EQ(models[i]->outputDim(), kOutDim);
+
+    // 순전파 검증
+    Eigen::VectorXd input = Eigen::VectorXd::Random(kInDim);
+    Eigen::VectorXd output = models[i]->forward(input);
+    EXPECT_EQ(output.size(), kOutDim);
+    for (int j = 0; j < kOutDim; ++j) {
+      EXPECT_TRUE(std::isfinite(output(j)));
+    }
+  }
+
+  // takeModels 후 내부 벡터는 비워져야 함
+  auto empty_models = reloader.takeModels();
+  EXPECT_TRUE(empty_models.empty());
+}
+
+// =============================================================================
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/ros2_ws/src/mpc_controller_ros2/test/unit/test_predictive_safety.cpp
+++ b/ros2_ws/src/mpc_controller_ros2/test/unit/test_predictive_safety.cpp
@@ -1,0 +1,389 @@
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+#include <cmath>
+
+#include "mpc_controller_ros2/predictive_safety_filter.hpp"
+#include "mpc_controller_ros2/barrier_function.hpp"
+#include "mpc_controller_ros2/motion_model.hpp"
+#include "mpc_controller_ros2/motion_model_factory.hpp"
+#include "mpc_controller_ros2/mppi_params.hpp"
+
+using namespace mpc_controller_ros2;
+
+// =============================================================================
+// 테스트 Fixture
+// =============================================================================
+
+class PredictiveSafetyTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    MPPIParams params;
+    params.dt = 0.05;
+    model_ = MotionModelFactory::create("diff_drive", params);
+
+    barrier_set_ = std::make_unique<BarrierFunctionSet>(0.2, 0.3);
+
+    Eigen::VectorXd u_min(2), u_max(2);
+    u_min << -1.0, -2.0;
+    u_max << 1.0, 2.0;
+    filter_ = std::make_unique<PredictiveSafetyFilter>(
+      barrier_set_.get(), 1.0, 0.05, u_min, u_max);
+  }
+
+  // 직진 제어 시퀀스 생성: v, omega 일정
+  Eigen::MatrixXd makeStraightControls(int N, double v, double omega) {
+    Eigen::MatrixXd controls(N, 2);
+    controls.col(0).setConstant(v);
+    controls.col(1).setConstant(omega);
+    return controls;
+  }
+
+  std::shared_ptr<MotionModel> model_;
+  std::unique_ptr<BarrierFunctionSet> barrier_set_;
+  std::unique_ptr<PredictiveSafetyFilter> filter_;
+};
+
+// =============================================================================
+// PredictiveSafetyFilter_Basic (4개)
+// =============================================================================
+
+TEST_F(PredictiveSafetyTest, NoObstacles_PassThrough) {
+  // 장애물 없음 → u_safe == u_orig, num_corrected == 0
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 0.5, 0.1);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_TRUE(result.feasible);
+  EXPECT_EQ(result.num_corrected_steps, 0);
+  // 투영 없으므로 제어가 동일
+  for (int t = 0; t < N; ++t) {
+    EXPECT_NEAR(result.u_safe_sequence(t, 0), controls(t, 0), 1e-6);
+    EXPECT_NEAR(result.u_safe_sequence(t, 1), controls(t, 1), 1e-6);
+  }
+}
+
+TEST_F(PredictiveSafetyTest, Construction_ValidParams) {
+  // 기본 생성 파라미터 확인
+  EXPECT_EQ(filter_->maxIterations(), 10);
+  EXPECT_NEAR(filter_->horizonDecay(), 1.0, 1e-10);
+
+  // setter 반영 확인
+  filter_->setMaxIterations(20);
+  filter_->setHorizonDecay(0.95);
+  EXPECT_EQ(filter_->maxIterations(), 20);
+  EXPECT_NEAR(filter_->horizonDecay(), 0.95, 1e-10);
+}
+
+TEST_F(PredictiveSafetyTest, EmptyControlSequence) {
+  // 0행 제어 시퀀스 → N+1=1 궤적 (초기 상태만)
+  Eigen::VectorXd x0(3);
+  x0 << 1.0, 2.0, 0.5;
+
+  Eigen::MatrixXd controls(0, 2);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_EQ(result.u_safe_sequence.rows(), 0);
+  EXPECT_EQ(result.safe_trajectory.rows(), 1);
+  EXPECT_EQ(result.safe_trajectory.cols(), 3);
+  // 초기 상태 보존
+  EXPECT_NEAR(result.safe_trajectory(0, 0), 1.0, 1e-6);
+  EXPECT_NEAR(result.safe_trajectory(0, 1), 2.0, 1e-6);
+  EXPECT_EQ(result.num_corrected_steps, 0);
+}
+
+TEST_F(PredictiveSafetyTest, OutputDimensions) {
+  // 출력 차원 확인: u_safe (N x nu), trajectory (N+1 x nx)
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 15;
+  Eigen::MatrixXd controls = makeStraightControls(N, 0.3, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_EQ(result.u_safe_sequence.rows(), N);
+  EXPECT_EQ(result.u_safe_sequence.cols(), 2);  // nu=2 for diff_drive
+  EXPECT_EQ(result.safe_trajectory.rows(), N + 1);
+  EXPECT_EQ(result.safe_trajectory.cols(), 3);   // nx=3 for diff_drive
+  EXPECT_EQ(static_cast<int>(result.min_barrier_values.size()), N + 1);
+}
+
+// =============================================================================
+// PredictiveSafetyFilter_SafetyProjection (6개)
+// =============================================================================
+
+TEST_F(PredictiveSafetyTest, UnsafeTrajectory_GetsCorrected) {
+  // 장애물에 정면 돌진 → 보정됨
+  barrier_set_->setObstacles({{1.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;  // 원점, 오른쪽 방향
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_GT(result.num_corrected_steps, 0)
+    << "Trajectory heading into obstacle should be corrected";
+  EXPECT_TRUE(result.feasible);
+}
+
+TEST_F(PredictiveSafetyTest, SafeTrajectory_Unchanged) {
+  // 장애물 반대 방향 → 보정 없음
+  barrier_set_->setObstacles({{5.0, 5.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, M_PI;  // 왼쪽 방향 (장애물 반대)
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 0.5, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_EQ(result.num_corrected_steps, 0)
+    << "Safe trajectory should not be corrected";
+  EXPECT_TRUE(result.feasible);
+}
+
+TEST_F(PredictiveSafetyTest, MultistepPropagation) {
+  // t 스텝 보정이 t+1..N에 전파되는지 확인
+  // 장애물을 앞에 놓고, 보정 후 궤적이 장애물을 회피하는지 확인
+  barrier_set_->setObstacles({{1.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  // 안전 궤적의 모든 포인트가 장애물 안전 거리 밖인지 확인
+  double obs_x = 1.0, obs_y = 0.0, obs_r = 0.2;
+  double d_safe = obs_r + 0.2 + 0.3;  // obstacle_r + robot_r + safety_margin
+  for (int t = 0; t <= N; ++t) {
+    double dx = result.safe_trajectory(t, 0) - obs_x;
+    double dy = result.safe_trajectory(t, 1) - obs_y;
+    double dist = std::sqrt(dx * dx + dy * dy);
+    // 보정 후 안전 거리 이상이어야 함 (약간의 여유)
+    EXPECT_GT(dist, d_safe * 0.5)
+      << "Step " << t << " too close to obstacle after filtering";
+  }
+}
+
+TEST_F(PredictiveSafetyTest, MultipleObstacles_AllAvoided) {
+  // 여러 장애물 배치 → 필터 후 모든 barrier 값이 양수
+  barrier_set_->setObstacles({
+    {1.0, 0.0, 0.2},
+    {0.0, 1.0, 0.2},
+    {0.7, 0.7, 0.2}
+  });
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, M_PI / 4.0;  // 45도 방향
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 0.8, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  // 필터 적용 후 모든 스텝의 min_barrier_values가 >= 0에 가까운지 확인
+  for (int t = 0; t < N; ++t) {
+    EXPECT_GE(result.min_barrier_values[t], -0.1)
+      << "Step " << t << " barrier value too negative after filtering";
+  }
+}
+
+TEST_F(PredictiveSafetyTest, CloseObstacle_HighCorrection) {
+  // 가까운 장애물(0.8m) → 상당한 보정
+  barrier_set_->setObstacles({{0.8, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_GT(result.num_corrected_steps, 0);
+
+  // 보정 후 제어가 원래와 크게 다른 스텝이 있어야 함
+  double max_diff = 0.0;
+  for (int t = 0; t < N; ++t) {
+    double diff = (result.u_safe_sequence.row(t) - controls.row(t)).norm();
+    max_diff = std::max(max_diff, diff);
+  }
+  EXPECT_GT(max_diff, 0.01)
+    << "Close obstacle should cause significant control correction";
+}
+
+TEST_F(PredictiveSafetyTest, FarObstacle_NoCorrection) {
+  // 먼 장애물(5.0m) → 보정 없음
+  barrier_set_->setObstacles({{5.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  // dt=0.05, N=10 → 총 0.5초, v=0.5 → 0.25m 전진 (5.0m 장애물까지 여유)
+  Eigen::MatrixXd controls = makeStraightControls(N, 0.5, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  EXPECT_EQ(result.num_corrected_steps, 0)
+    << "Far obstacle should not require correction";
+  EXPECT_TRUE(result.feasible);
+}
+
+// =============================================================================
+// PredictiveSafetyFilter_VerifyTrajectory (3개)
+// =============================================================================
+
+TEST_F(PredictiveSafetyTest, VerifySafeTrajectory_ReturnsTrue) {
+  // 장애물에서 멀리 떨어진 안전 궤적
+  barrier_set_->setObstacles({{5.0, 5.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 0.3, 0.0);
+
+  bool safe = filter_->verifyTrajectory(x0, controls, *model_);
+  EXPECT_TRUE(safe);
+}
+
+TEST_F(PredictiveSafetyTest, VerifyUnsafeTrajectory_ReturnsFalse) {
+  // 장애물 돌진 궤적 → false
+  barrier_set_->setObstacles({{1.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  bool safe = filter_->verifyTrajectory(x0, controls, *model_);
+  EXPECT_FALSE(safe)
+    << "Trajectory heading into obstacle should be unsafe";
+}
+
+TEST_F(PredictiveSafetyTest, FilteredTrajectory_VerifyTrue) {
+  // 필터 적용 후 → verifyTrajectory가 true
+  barrier_set_->setObstacles({{1.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  // 먼저 필터 적용
+  auto result = filter_->filter(x0, controls, *model_);
+  ASSERT_TRUE(result.feasible);
+
+  // 필터된 제어로 검증
+  bool safe = filter_->verifyTrajectory(x0, result.u_safe_sequence, *model_);
+  EXPECT_TRUE(safe)
+    << "Filtered trajectory should pass verification";
+}
+
+// =============================================================================
+// PredictiveSafetyFilter_HorizonDecay (3개)
+// =============================================================================
+
+TEST_F(PredictiveSafetyTest, DecayOne_UniformGamma) {
+  // decay=1.0 → 모든 스텝에서 동일한 gamma
+  // 장애물을 배치하고, 보정 정도가 스텝 간 감쇠하지 않는지 확인
+  filter_->setHorizonDecay(1.0);
+
+  barrier_set_->setObstacles({{1.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  auto result = filter_->filter(x0, controls, *model_);
+
+  // decay=1 → 균일 gamma → 후반 스텝에서도 적극적 보정
+  // (feasible이면 OK)
+  EXPECT_TRUE(result.feasible);
+  EXPECT_NEAR(filter_->horizonDecay(), 1.0, 1e-10);
+}
+
+TEST_F(PredictiveSafetyTest, DecayLessThanOne_WeakerAtEnd) {
+  // decay < 1 → 후반 스텝에서 gamma가 약해짐
+  // decay=1 vs decay=0.8의 결과를 비교
+  barrier_set_->setObstacles({{1.5, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  // decay=1.0 (균일)
+  filter_->setHorizonDecay(1.0);
+  auto result_uniform = filter_->filter(x0, controls, *model_);
+
+  // decay=0.8 (감쇠)
+  filter_->setHorizonDecay(0.8);
+  auto result_decay = filter_->filter(x0, controls, *model_);
+
+  // 두 결과 모두 유효해야 함
+  EXPECT_TRUE(result_uniform.feasible);
+  EXPECT_TRUE(result_decay.feasible);
+
+  // decay < 1 에서는 후반부 CBF 제약이 약하므로
+  // 보정 수가 다르거나, 제어 시퀀스가 다를 수 있음
+  bool different = false;
+  for (int t = 0; t < N; ++t) {
+    if ((result_uniform.u_safe_sequence.row(t) -
+         result_decay.u_safe_sequence.row(t)).norm() > 1e-6) {
+      different = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(different)
+    << "Different decay should produce different filtered controls";
+}
+
+TEST_F(PredictiveSafetyTest, DecayZero_OnlyFirstStep) {
+  // decay=0 → gamma_t = gamma * 0^t
+  //   t=0: gamma * 1 = gamma (활성)
+  //   t>=1: gamma * 0 = 0 (비활성)
+  barrier_set_->setObstacles({{1.0, 0.0, 0.2}});
+
+  Eigen::VectorXd x0(3);
+  x0 << 0.0, 0.0, 0.0;
+
+  int N = 10;
+  Eigen::MatrixXd controls = makeStraightControls(N, 1.0, 0.0);
+
+  // decay=0 → 첫 스텝만 CBF 투영
+  filter_->setHorizonDecay(0.0);
+  auto result = filter_->filter(x0, controls, *model_);
+
+  // decay=1 (전체 투영)과 비교 → decay=0이 보정이 더 적어야 함
+  filter_->setHorizonDecay(1.0);
+  auto result_full = filter_->filter(x0, controls, *model_);
+
+  EXPECT_LE(result.num_corrected_steps, result_full.num_corrected_steps)
+    << "Decay=0 should correct fewer steps than decay=1";
+}
+
+// =============================================================================
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- **다중 CBF 합성** (Closes #162): smooth-min, log-sum-exp, product 합성으로 N개 CBF → 단일 제약 QP 수렴 개선
- **Online Residual Learning** (Closes #163): OnlineDataCollector + ModelReloader로 런타임 앙상블 MLP 핫 스왑
- **Predictive Safety Filter** (Closes #164): N-step forward rollout CBF 투영으로 recursive feasibility 보장, 20번째 nav2 플러그인

## Architecture

```
                                    ┌──────────────────┐
                                    │  CBF Composition  │
                                    │ (smooth-min, LSE, │
                                    │  product)         │
                                    └────────┬─────────┘
                                             │
MPPIControllerPlugin ──► ShieldMPPI ──► CLF-CBF-QP ──► solveComposite()
                              │                              │
                              └──► PredictiveSafetyMPPI ─────┘
                                   (N-step forward CBF)

OnlineDataCollector ──► OnlineDataBuffer ──► CSV export
                                              ↓
                        ModelReloader ◄── train (외부)
                              │
                              └──► EnsembleDynamicsModel::updateEnsemble()
```

## Changes

### NEW (10 files)
| File | Description |
|------|------------|
| `online_data_collector.hpp/cpp` | Thread-safe 데이터 수집기 (atomic + mutex) |
| `model_reloader.hpp/cpp` | 디스크 타임스탬프 모니터링 + MLP 핫 리로드 |
| `predictive_safety_filter.hpp/cpp` | N-step CBF 투영 (horizon decay, max iterations) |
| `predictive_safety_mppi_controller_plugin.hpp/cpp` | 20번째 nav2 플러그인 |
| `test_cbf_composition.cpp` | 15 tests |
| `test_online_learning.cpp` | 12 tests |
| `test_predictive_safety.cpp` | 16 tests |

### MODIFIED (10 files)
| File | Change |
|------|--------|
| `barrier_function.hpp/cpp` | CBFCompositionMethod enum + evaluateComposite/compositeGradient |
| `clf_cbf_qp_solver.hpp/cpp` | solveComposite() 합성 CBF QP |
| `ensemble_dynamics_model.hpp/cpp` | updateEnsemble() 핫 스왑 + mutex 보호 |
| `mppi_params.hpp` | 9개 파라미터 추가 |
| `mppi_controller_plugin.cpp` | declare/load 파라미터 |
| `mppi_controller_plugin.xml` | PredictiveSafetyMPPI 등록 (20번째) |

## Test plan
- [x] 43개 신규 gtest PASS (15 + 12 + 16)
- [x] 기존 451개 gtest 회귀 통과 (총 494)
- [x] colcon build 성공
- [ ] `controller:=predictive_safety` 런타임 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)