### PR TITLE
chore: Swerve 벤치마크 설정 파일 정리

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_biased_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_biased_swerve_mppi.yaml
@@ -1,0 +1,122 @@
+# ============================================================
+# nav2 파라미터 - Biased-MPPI + Swerve Drive (RA-L 2024)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=biased_swerve
+#
+# Biased-MPPI (ancillary 결정적 시퀀스 주입) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- Biased-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::BiasedMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 1024
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # Biased-MPPI 전용 파라미터
+      biased_enabled: true
+      bias_ratio: 0.1
+      biased_braking: true
+      biased_goto_goal: true
+      biased_path_following: true
+      biased_previous_solution: true
+      biased_goto_goal_gain: 1.0
+      biased_path_following_gain: 1.0
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_cs_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_cs_swerve_mppi.yaml
@@ -1,0 +1,119 @@
+# ============================================================
+# nav2 파라미터 - CS-MPPI Covariance Steering + Swerve Drive
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=cs_swerve
+#
+# CS-MPPI (CoVO-MPC CoRL 2023, Jacobian B_t 기반 노이즈 적응) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- CS-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::CSMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 512
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # Covariance Steering (CS-MPPI) 전용
+      cs_enabled: true
+      cs_scale_min: 0.1
+      cs_scale_max: 3.0
+      cs_feedback_enabled: false
+      cs_feedback_gain: 0.5
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_ilqr_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_ilqr_swerve_mppi.yaml
@@ -1,0 +1,119 @@
+# ============================================================
+# nav2 파라미터 - iLQR Warm-Start MPPI + Swerve Drive
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=ilqr_swerve
+#
+# iLQR(1-2 iter) warm-start + MPPI sampling + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- iLQR-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::IlqrMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 512
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # iLQR Warm-Start 전용
+      ilqr_enabled: true
+      ilqr_max_iterations: 2
+      ilqr_regularization: 1.0e-6
+      ilqr_line_search_steps: 4
+      ilqr_cost_tolerance: 1.0e-4
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_log_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_log_swerve_mppi.yaml
@@ -1,0 +1,112 @@
+# ============================================================
+# nav2 파라미터 - Log-MPPI + Swerve Drive
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=log_swerve
+#
+# Log-MPPI (log-space 가중치, 수치 안정성 향상) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- Log-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::LogMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 1024
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_pi_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_pi_swerve_mppi.yaml
@@ -1,0 +1,122 @@
+# ============================================================
+# nav2 파라미터 - pi-MPPI Projection + Swerve Drive (RA-L 2025)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=pi_swerve
+#
+# pi-MPPI (ADMM QP 투영 필터, rate/accel hard bounds) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- pi-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::PiMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 512
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # pi-MPPI Projection Filter 전용
+      pi_enabled: true
+      pi_admm_iterations: 10
+      pi_admm_rho: 1.0
+      pi_derivative_order: 2
+      pi_rate_max_v: 2.0
+      pi_rate_max_omega: 3.0
+      pi_accel_max_v: 5.0
+      pi_accel_max_omega: 8.0
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_shield_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_shield_swerve_mppi.yaml
@@ -1,0 +1,141 @@
+# ============================================================
+# nav2 파라미터 - Shield-MPPI + Swerve Drive
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=shield_swerve
+#
+# Shield-MPPI (per-step CBF + BR-MPPI + Conformal) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    progress_checker:
+      required_movement_radius: 0.1
+      movement_time_allowance: 60.0
+
+    goal_checker:
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.5
+
+    # ---- Shield-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::ShieldMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 256
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.4
+      noise_sigma_vy: 0.3
+      noise_sigma_omega: 0.6
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # CBF 안전 필터
+      cbf_enabled: true
+      cbf_gamma: 0.5
+      cbf_safety_margin: 0.2
+      cbf_robot_radius: 0.2
+      cbf_activation_distance: 1.5
+      cbf_use_safety_filter: false
+
+      # Shield-MPPI 전용
+      shield_cbf_stride: 5
+      shield_max_iterations: 5
+
+      # BR-MPPI (Barrier Rate Cost)
+      barrier_rate_cost_weight: 10.0
+
+      # Conformal Predictor
+      conformal_enabled: true
+      conformal_coverage: 0.90
+      conformal_window_size: 100
+      conformal_initial_margin: 0.1
+      conformal_min_margin: 0.05
+      conformal_max_margin: 0.3
+      conformal_decay_rate: 0.99
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: false
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_smooth_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_smooth_swerve_mppi.yaml
@@ -1,0 +1,131 @@
+# ============================================================
+# nav2 파라미터 - Smooth-MPPI + Swerve Drive (Kim et al. 2021)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=smooth_swerve
+#
+# Smooth-MPPI (Δu space 최적화 + jerk cost) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- Smooth-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::SmoothMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 512
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # Smooth-MPPI 전용 파라미터
+      smooth_R_jerk_v: 0.1
+      smooth_R_jerk_omega: 0.1
+      smooth_action_cost_weight: 1.0
+
+      # SOTA 변형 (기본값)
+      tsallis_q: 1.5
+      cvar_alpha: 0.5
+      svgd_num_iterations: 0
+      svgd_step_size: 0.1
+      svgd_bandwidth: -1.0
+      spline_num_knots: 8
+      spline_degree: 3
+      svg_num_guide_particles: 10
+      svg_guide_iterations: 3
+      svg_guide_step_size: 0.1
+      svg_resample_std: 0.3
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      visualize_tube: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_svg_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_svg_swerve_mppi.yaml
@@ -1,0 +1,133 @@
+# ============================================================
+# nav2 파라미터 - SVG-MPPI + Swerve Drive (Kondo et al., ICRA 2024)
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=svg_swerve
+#
+# SVG-MPPI (Guide SVGD + follower 리샘플링) + Swerve 홀로노믹 구동
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- SVG-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::SVGMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 512
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # SVG-MPPI 전용 파라미터
+      svg_num_guide_particles: 10
+      svg_guide_iterations: 3
+      svg_guide_step_size: 0.1
+      svg_resample_std: 0.3
+
+      # SVGD 기반 파라미터
+      svgd_num_iterations: 3
+      svgd_step_size: 0.1
+      svgd_bandwidth: -1.0
+
+      # SOTA 변형 (기본값)
+      tsallis_q: 1.5
+      cvar_alpha: 0.5
+      smooth_R_jerk_v: 0.1
+      smooth_R_jerk_omega: 0.1
+      smooth_action_cost_weight: 1.0
+      spline_num_knots: 8
+      spline_degree: 3
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      visualize_tube: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_swerve_stress.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_swerve_stress.yaml
@@ -1,0 +1,273 @@
+# ============================================================
+# nav2 공통 파라미터 - Swerve Drive (스트레스 테스트용)
+# ============================================================
+# 글로벌 플래너 보호를 최소화하여 로컬 컨트롤러의
+# 반응적 장애물 회피 능력을 직접 평가.
+#
+# 변경점 (nav2_params_swerve.yaml 대비):
+#   - global costmap: inflation_radius 0.35→0.10, robot_radius 0.3→0.1
+#   - local costmap: inflation_radius 0.35→0.15
+#   - planner_frequency: 20→1 Hz (재계획 최소화)
+#   - progress_checker: movement_time_allowance 30→120s (여유)
+# ============================================================
+
+amcl:
+  ros__parameters:
+    use_sim_time: true
+    alpha1: 0.005
+    alpha2: 0.005
+    alpha3: 0.01
+    alpha4: 0.001
+    alpha5: 0.005
+    base_frame_id: "base_link"
+    beam_skip_distance: 0.5
+    beam_skip_error_threshold: 0.9
+    beam_skip_threshold: 0.3
+    do_beamskip: false
+    global_frame_id: "map"
+    lambda_short: 0.1
+    laser_likelihood_max_dist: 5.0
+    laser_max_range: 10.0
+    laser_min_range: 0.12
+    laser_model_type: "likelihood_field"
+    max_beams: 120
+    max_particles: 5000
+    min_particles: 1000
+    odom_frame_id: "odom"
+    pf_err: 0.05
+    pf_z: 0.99
+    recovery_alpha_fast: 0.1
+    recovery_alpha_slow: 0.001
+    resample_interval: 1
+    robot_model_type: "nav2_amcl::OmniMotionModel"
+    save_pose_rate: 0.5
+    sigma_hit: 0.1
+    tf_broadcast: true
+    transform_tolerance: 1.0
+    update_min_a: 0.1
+    update_min_d: 0.1
+    z_hit: 0.7
+    z_max: 0.05
+    z_rand: 0.2
+    z_short: 0.05
+    scan_topic: /scan
+    set_initial_pose: true
+    initial_pose.x: 0.0
+    initial_pose.y: 0.0
+    initial_pose.z: 0.0
+    initial_pose.yaw: 0.0
+
+bt_navigator:
+  ros__parameters:
+    use_sim_time: true
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /swerve_controller/odom
+    bt_loop_duration: 10
+    default_server_timeout: 20
+    wait_for_service_timeout: 1000
+    action_server_result_timeout: 900.0
+    navigators: ["navigate_to_pose", "navigate_through_poses"]
+    navigate_to_pose:
+      plugin: "nav2_bt_navigator::NavigateToPoseNavigator"
+    navigate_through_poses:
+      plugin: "nav2_bt_navigator::NavigateThroughPosesNavigator"
+    error_code_names:
+      - compute_path_error_code
+      - follow_path_error_code
+
+controller_server:
+  ros__parameters:
+    use_sim_time: true
+    controller_frequency: 20.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.001
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.5
+    transform_tolerance: 1.0
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["goal_checker"]
+    controller_plugins: ["FollowPath"]
+
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.1
+      movement_time_allowance: 120.0    # 30→120s (스트레스 테스트 여유)
+
+    goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.35
+      yaw_goal_tolerance: 0.5
+      stateful: true
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      use_sim_time: true
+      global_frame: odom
+      robot_base_frame: base_link
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      rolling_window: true
+      width: 10
+      height: 10
+      resolution: 0.05
+      robot_radius: 0.15              # 0.3→0.15 (축소)
+      plugins: ["obstacle_layer", "voxel_layer", "inflation_layer"]
+
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: true
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: true
+          marking: true
+          data_type: "LaserScan"
+          raytrace_max_range: 10.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 9.5
+          obstacle_min_range: 0.0
+      transform_tolerance: 1.0
+
+      voxel_layer:
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: true
+        publish_voxel_map: true
+        origin_z: 0.0
+        z_resolution: 0.05
+        z_voxels: 16
+        max_obstacle_height: 2.0
+        mark_threshold: 0
+        observation_sources: depth_points
+        depth_points:
+          topic: /depth/points
+          max_obstacle_height: 2.0
+          min_obstacle_height: 0.05
+          clearing: true
+          marking: true
+          data_type: "PointCloud2"
+          raytrace_max_range: 5.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 4.5
+          obstacle_min_range: 0.0
+
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        enabled: true
+        cost_scaling_factor: 5.0       # 10→5 (약한 감쇠)
+        inflation_radius: 0.15         # 0.35→0.15 (최소 inflation)
+
+      always_send_full_costmap: true
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      use_sim_time: true
+      global_frame: map
+      robot_base_frame: base_link
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      rolling_window: false
+      width: 50
+      height: 50
+      resolution: 0.05
+      robot_radius: 0.1               # 0.3→0.1 (글로벌 플래너가 벽 근처 경로 허용)
+      track_unknown_space: true
+      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"]
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: true
+
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: true
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: true
+          marking: true
+          data_type: "LaserScan"
+          raytrace_max_range: 10.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 9.5
+          obstacle_min_range: 0.0
+      transform_tolerance: 1.0
+
+      voxel_layer:
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: true
+        publish_voxel_map: false
+        origin_z: 0.0
+        z_resolution: 0.05
+        z_voxels: 16
+        max_obstacle_height: 2.0
+        mark_threshold: 0
+        observation_sources: depth_points
+        depth_points:
+          topic: /depth/points
+          max_obstacle_height: 2.0
+          min_obstacle_height: 0.05
+          clearing: true
+          marking: true
+          data_type: "PointCloud2"
+          raytrace_max_range: 5.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 4.5
+          obstacle_min_range: 0.0
+
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        enabled: true
+        cost_scaling_factor: 3.0       # 10→3 (약한 감쇠, 벽 근처 비용 낮음)
+        inflation_radius: 0.10         # 0.35→0.10 (거의 무 inflation)
+
+      always_send_full_costmap: true
+
+planner_server:
+  ros__parameters:
+    use_sim_time: true
+    expected_planner_frequency: 1.0    # 20→1 Hz (재계획 최소화)
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner::NavfnPlanner"
+      tolerance: 0.5
+      use_astar: false
+      allow_unknown: true
+
+behavior_server:
+  ros__parameters:
+    use_sim_time: true
+    local_costmap_topic: local_costmap/costmap_raw
+    global_costmap_topic: global_costmap/costmap_raw
+    local_footprint_topic: local_costmap/published_footprint
+    global_footprint_topic: global_costmap/published_footprint
+    cycle_frequency: 10.0
+    behavior_plugins: ["spin", "backup", "wait"]
+    spin:
+      plugin: "nav2_behaviors::Spin"
+    backup:
+      plugin: "nav2_behaviors::BackUp"
+    wait:
+      plugin: "nav2_behaviors::Wait"
+    local_frame: odom
+    global_frame: map
+    robot_base_frame: base_link
+    transform_tolerance: 1.0
+
+velocity_smoother:
+  ros__parameters:
+    use_sim_time: true
+    smoothing_frequency: 20.0
+    scale_velocities: false
+    feedback: "OPEN_LOOP"
+    max_velocity: [1.5, 1.5, 2.0]
+    min_velocity: [-1.5, -1.5, -2.0]
+    max_accel: [1.0, 1.0, 2.0]
+    max_decel: [-1.0, -1.0, -2.0]
+    odom_topic: "/swerve_controller/odom"
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0

--- a/ros2_ws/src/mpc_controller_ros2/config/nav2_params_tsallis_swerve_mppi.yaml
+++ b/ros2_ws/src/mpc_controller_ros2/config/nav2_params_tsallis_swerve_mppi.yaml
@@ -1,0 +1,116 @@
+# ============================================================
+# nav2 파라미터 - Tsallis-MPPI + Swerve Drive
+# ============================================================
+# 사용법:
+#   ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py controller:=tsallis_swerve
+#
+# Tsallis-MPPI (q-exponential 가중치) + Swerve 홀로노믹 구동
+# q>1: heavy-tail 탐색, q<1: light-tail 집중, q=1: Vanilla
+# ============================================================
+
+controller_server:
+  ros__parameters:
+    controller_frequency: 20.0
+
+    goal_checker:
+      yaw_goal_tolerance: 0.4
+
+    # ---- Tsallis-MPPI Swerve Controller ----
+    FollowPath:
+      plugin: "mpc_controller_ros2::TsallisMPPIControllerPlugin"
+      motion_model: "swerve"
+
+      # Tsallis 고유 파라미터
+      tsallis_q: 1.5
+
+      # Prediction horizon (2초)
+      N: 40
+      dt: 0.05
+
+      # Sampling
+      K: 1024
+      lambda: 100.0
+
+      # Noise parameters (vx, vy, omega)
+      noise_sigma_v: 0.5
+      noise_sigma_vy: 0.4
+      noise_sigma_omega: 0.8
+
+      # Control limits
+      v_max: 1.5
+      v_min: -0.3
+      omega_max: 2.0
+      omega_min: -2.0
+      vy_max: 0.5
+
+      # State tracking cost weights (Q)
+      Q_x: 10.0
+      Q_y: 10.0
+      Q_theta: 15.0
+
+      # Terminal cost weights (Qf)
+      Qf_x: 20.0
+      Qf_y: 20.0
+      Qf_theta: 20.0
+
+      # Control effort weights (R)
+      R_v: 0.1
+      R_vy: 1.0
+      R_omega: 0.3
+
+      # Control rate weights (R_rate)
+      R_rate_v: 0.3
+      R_rate_vy: 0.8
+      R_rate_omega: 1.0
+
+      # Obstacle avoidance
+      obstacle_weight: 0.0
+      safety_distance: 0.4
+
+      # Costmap obstacle cost
+      use_costmap_cost: true
+      costmap_lethal_cost: 200.0
+      costmap_critical_cost: 50.0
+      lookahead_dist: 2.0
+      min_lookahead: 0.5
+      goal_slowdown_dist: 0.5
+      ref_theta_smooth_window: 5
+
+      # Velocity Tracking Cost
+      velocity_tracking_weight: 10.0
+      reference_velocity: 1.0
+
+      # Forward preference
+      prefer_forward_weight: 5.0
+      prefer_forward_linear_ratio: 0.5
+      prefer_forward_velocity_incentive: 1.0
+
+      # Trajectory Stability
+      sg_filter_enabled: true
+      sg_half_window: 4
+      sg_poly_order: 5
+      it_alpha: 0.975
+      exploration_ratio: 0.1
+
+      # Adaptive Temperature
+      adaptive_temperature: true
+      target_ess_ratio: 0.3
+      adaptation_rate: 0.1
+      lambda_min: 1.0
+      lambda_max: 500.0
+
+      # Non-Coaxial (declare 필수)
+      noise_sigma_delta_dot: 0.3
+      R_delta_dot: 0.5
+      R_rate_delta_dot: 1.0
+      max_steering_rate: 2.0
+      max_steering_angle: 1.5707
+
+      # Visualization
+      visualize_samples: true
+      visualize_best: true
+      visualize_weighted_avg: true
+      visualize_reference: true
+      visualize_text_info: true
+      visualize_control_sequence: true
+      max_visualized_samples: 20

--- a/ros2_ws/src/mpc_controller_ros2/scripts/swerve_controller_benchmark.sh
+++ b/ros2_ws/src/mpc_controller_ros2/scripts/swerve_controller_benchmark.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# =============================================================
+# swerve_controller_benchmark.sh
+# Swerve 모델 기반 다양한 MPPI 컨트롤러 성능 벤치마크
+#
+# 사용법:
+#   bash ros2_ws/src/mpc_controller_ros2/scripts/swerve_controller_benchmark.sh
+#
+# 각 컨트롤러별로:
+#   1. launch 시작 (swerve URDF)
+#   2. nav2 활성화 대기
+#   3. E2E goal 전송 + 메트릭 수집
+#   4. 정리 후 다음 컨트롤러
+# =============================================================
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_DIR="$(dirname "$SCRIPT_DIR")"
+CLEANUP_SCRIPT="$SCRIPT_DIR/cleanup_launch.sh"
+RESULTS_DIR="$HOME/swerve_benchmark_results"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS_FILE="$RESULTS_DIR/benchmark_${TIMESTAMP}.txt"
+
+# Swerve 호환 컨트롤러 목록 (장애물 회피 벤치마크)
+# 이전 벤치마크에서 상위 성능 + 특성 다양한 8종 선정
+CONTROLLERS=(
+    "swerve"
+    "non_coaxial"
+    "dial_swerve"
+    "log_swerve"
+    "smooth_swerve"
+    "biased_swerve"
+    "cs_swerve"
+    "pi_swerve"
+)
+
+# 목표 지점: barrier 2 (y=-2, gap at x=5) 통과 필수 경로
+# S(0,0) → barrier2 gap(x=5, y=-2) → G(5,-3.5)
+# 최소 1개 narrow passage (0.8m 폭) 통과 + pillar_2 (x=5, y=-3.5) 근처
+GOAL_X=5.0
+GOAL_Y=-3.5
+GOAL_YAW=0.0
+TIMEOUT=120
+LAUNCH_WAIT=35    # launch 후 안정화 대기 (초)
+NAV2_WAIT=30      # nav2 lifecycle 활성화 대기 (초)
+
+# World/Map 설정
+WORLD="narrow_passage_world.world"
+MAP="narrow_passage_map.yaml"
+
+mkdir -p "$RESULTS_DIR"
+
+echo "============================================================"
+echo "  Swerve Controller Benchmark"
+echo "  $(date)"
+echo "  World: $WORLD"
+echo "  Goal: ($GOAL_X, $GOAL_Y, yaw=$GOAL_YAW)"
+echo "  Controllers: ${CONTROLLERS[*]}"
+echo "============================================================"
+echo ""
+
+# 결과 헤더
+cat > "$RESULTS_FILE" << 'HEADER'
+============================================================
+  Swerve Controller Benchmark Results
+============================================================
+HEADER
+echo "Date: $(date)" >> "$RESULTS_FILE"
+echo "World: $WORLD" >> "$RESULTS_FILE"
+echo "Goal: ($GOAL_X, $GOAL_Y, yaw=$GOAL_YAW)" >> "$RESULTS_FILE"
+echo "" >> "$RESULTS_FILE"
+
+# Source ROS2
+source /opt/ros/jazzy/setup.bash
+source /home/geonhee/toy_claude_project/ros2_ws/install/setup.bash
+
+run_single_test() {
+    local ctrl="$1"
+    local idx="$2"
+    local total="$3"
+
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "  [$idx/$total] Testing: $ctrl"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # 1. 기존 프로세스 정리
+    echo "[cleanup] Cleaning up previous processes..."
+    bash "$CLEANUP_SCRIPT" 2>/dev/null || true
+    sleep 5
+
+    # 2. Launch 시작
+    echo "[launch] Starting controller=$ctrl world=$WORLD ..."
+    ros2 launch mpc_controller_ros2 mppi_ros2_control_nav2.launch.py \
+        controller:="$ctrl" \
+        world:="$WORLD" \
+        map:="$MAP" \
+        headless:=true \
+        nav2_stress:="${NAV2_STRESS:-false}" \
+        2>&1 | tee "/tmp/launch_${ctrl}.log" &
+    LAUNCH_PID=$!
+
+    echo "[launch] PID=$LAUNCH_PID, waiting ${LAUNCH_WAIT}s for stabilization..."
+    sleep "$LAUNCH_WAIT"
+
+    # launch가 살아있는지 확인
+    if ! kill -0 "$LAUNCH_PID" 2>/dev/null; then
+        echo "[ERROR] Launch crashed for $ctrl!"
+        echo "[$ctrl] LAUNCH_FAILED" >> "$RESULTS_FILE"
+        return 1
+    fi
+
+    # 3. nav2 활성화 대기
+    echo "[nav2] Waiting ${NAV2_WAIT}s for nav2 lifecycle activation..."
+    sleep "$NAV2_WAIT"
+
+    # bt_navigator 활성 확인 (goal 수락 가능 상태)
+    local nav2_ready=false
+    for i in $(seq 1 10); do
+        local bt_state=$(ros2 lifecycle get /bt_navigator 2>/dev/null)
+        local ctrl_state=$(ros2 lifecycle get /controller_server 2>/dev/null)
+        echo "[nav2] Check $i/10: bt_navigator=$bt_state, controller_server=$ctrl_state"
+        if echo "$bt_state" | grep -q "active" && echo "$ctrl_state" | grep -q "active"; then
+            nav2_ready=true
+            break
+        fi
+        sleep 5
+    done
+
+    if [ "$nav2_ready" = false ]; then
+        echo "[ERROR] nav2 not fully active for $ctrl!"
+        echo "[$ctrl] NAV2_NOT_ACTIVE" >> "$RESULTS_FILE"
+        kill "$LAUNCH_PID" 2>/dev/null || true
+        sleep 3
+        bash "$CLEANUP_SCRIPT" 2>/dev/null || true
+        return 1
+    fi
+
+    echo "[nav2] bt_navigator + controller_server active ✓"
+    # 추가 안정화 대기 (amcl map 수신 등)
+    sleep 10
+
+    # 4. E2E 테스트 실행
+    echo "[test] Running E2E test (goal: $GOAL_X, $GOAL_Y, timeout: ${TIMEOUT}s)..."
+    local test_output
+    test_output=$(ros2 run mpc_controller_ros2 swerve_e2e_test.py \
+        --x "$GOAL_X" --y "$GOAL_Y" --yaw "$GOAL_YAW" \
+        --timeout "$TIMEOUT" --no-save 2>&1) || true
+
+    echo "$test_output"
+
+    # 5. 결과 파싱 및 저장
+    echo "" >> "$RESULTS_FILE"
+    echo "━━━ $ctrl ━━━" >> "$RESULTS_FILE"
+    echo "$test_output" | grep -E "(Goal reached|Travel time|Travel distance|Position error|Yaw error|Mean.*:|Max.*:|Jerk.*:|Stall.*:|Min distance|Mean min|Near misses|Collisions)" >> "$RESULTS_FILE" 2>/dev/null || true
+
+    # 6. 정리
+    echo "[cleanup] Shutting down $ctrl..."
+    kill "$LAUNCH_PID" 2>/dev/null || true
+    sleep 3
+    bash "$CLEANUP_SCRIPT" 2>/dev/null || true
+    sleep 5
+
+    echo "[done] $ctrl complete"
+}
+
+# 메인 루프
+TOTAL=${#CONTROLLERS[@]}
+IDX=0
+for ctrl in "${CONTROLLERS[@]}"; do
+    IDX=$((IDX + 1))
+    run_single_test "$ctrl" "$IDX" "$TOTAL" || true
+done
+
+# 최종 요약
+echo ""
+echo "============================================================"
+echo "  Benchmark Complete!"
+echo "  Results: $RESULTS_FILE"
+echo "============================================================"
+echo ""
+cat "$RESULTS_FILE"

--- a/ros2_ws/src/mpc_controller_ros2/scripts/swerve_e2e_test.py
+++ b/ros2_ws/src/mpc_controller_ros2/scripts/swerve_e2e_test.py
@@ -22,6 +22,7 @@ from rclpy.action import ActionClient
 from nav2_msgs.action import NavigateToPose
 from geometry_msgs.msg import PoseStamped, Twist, TwistStamped
 from nav_msgs.msg import Odometry
+from sensor_msgs.msg import LaserScan
 import argparse
 import math
 import time
@@ -65,6 +66,12 @@ class E2EMetrics:
     num_stalls: int = 0                # 속도 < 0.01m/s 구간 수
     stall_ratio: float = 0.0           # 정체 비율 (0~1)
 
+    # 장애물 회피 메트릭
+    min_obstacle_dist: float = float('inf')   # 최소 장애물 거리 (m)
+    mean_obstacle_dist: float = 0.0           # 평균 최소 장애물 거리 (m)
+    num_near_misses: int = 0                  # 근접 위험 횟수 (< 0.3m)
+    num_collisions: int = 0                   # 충돌 횟수 (< 0.15m, ~로봇 반경)
+
     num_samples: int = 0
 
 
@@ -100,6 +107,13 @@ class SwerveE2ETest(Node):
         self.gz_odom_sub = self.create_subscription(
             Odometry, '/model/swerve_robot/odometry', self.odom_callback, 10)
 
+        # LaserScan 구독 (장애물 거리 추적)
+        self.scan_sub = self.create_subscription(
+            LaserScan, '/scan', self.scan_callback, 10)
+        self.min_scan_distances: List[float] = []  # 매 스캔의 최소 거리 기록
+        self.collision_threshold = 0.15   # 충돌 판정 (m, ~로봇 반경)
+        self.near_miss_threshold = 0.3    # 근접 위험 판정 (m)
+
         # nav2 action client
         if not args.record_only:
             self._action_client = ActionClient(
@@ -107,6 +121,14 @@ class SwerveE2ETest(Node):
 
         self.get_logger().info(
             f'Swerve E2E Test 초기화 (goal: x={args.x}, y={args.y}, timeout={args.timeout}s)')
+
+    def scan_callback(self, msg):
+        """LaserScan에서 최소 장애물 거리 추적"""
+        valid_ranges = [r for r in msg.ranges
+                        if msg.range_min < r < msg.range_max]
+        if valid_ranges:
+            min_dist = min(valid_ranges)
+            self.min_scan_distances.append(min_dist)
 
     def odom_callback(self, msg):
         self.last_odom_x = msg.pose.pose.position.x
@@ -261,6 +283,18 @@ class SwerveE2ETest(Node):
         m.num_stalls = stall_count
         m.stall_ratio = stall_count / n if n > 0 else 0.0
 
+        # 장애물 회피 메트릭 (LaserScan 기반)
+        if self.min_scan_distances:
+            m.min_obstacle_dist = min(self.min_scan_distances)
+            m.mean_obstacle_dist = (sum(self.min_scan_distances)
+                                    / len(self.min_scan_distances))
+            m.num_near_misses = sum(
+                1 for d in self.min_scan_distances
+                if d < self.near_miss_threshold)
+            m.num_collisions = sum(
+                1 for d in self.min_scan_distances
+                if d < self.collision_threshold)
+
         return m
 
     def print_report(self, metrics: E2EMetrics):
@@ -289,6 +323,12 @@ class SwerveE2ETest(Node):
         print('  Stall detection')
         print(f'    Stall samples  : {metrics.num_stalls} / {metrics.num_samples}')
         print(f'    Stall ratio    : {metrics.stall_ratio:.1%}')
+        print('-' * 60)
+        print('  Obstacle avoidance')
+        print(f'    Min distance   : {metrics.min_obstacle_dist:.3f} m')
+        print(f'    Mean min dist  : {metrics.mean_obstacle_dist:.3f} m')
+        print(f'    Near misses    : {metrics.num_near_misses} (<0.3m)')
+        print(f'    Collisions     : {metrics.num_collisions} (<0.15m)')
         print('=' * 60)
         print()
 


### PR DESCRIPTION
## Summary
- Swerve 모델용 MPPI 변형 nav2_params YAML 10종 추가 (biased/cs/ilqr/log/pi/shield/smooth/svg/tsallis + stress)
- `swerve_controller_benchmark.sh`: 8종 컨트롤러 자동 벤치마크 스크립트
- `swerve_e2e_test.py`: LaserScan 기반 장애물 회피 메트릭 추가 (min_obstacle_dist, near_misses, collisions)

## Test plan
- [x] launch 파일에 swerve 변형 컨트롤러 분기 포함 확인
- [ ] `bash swerve_controller_benchmark.sh` 실행하여 8종 벤치마크 동작 확인

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)