### PR TITLE
feat: 컨트롤러 벤치마크 대시보드

### DIFF
--- a/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
+++ b/ros2_ws/src/mpc_controller_ros2/CMakeLists.txt
@@ -192,6 +192,8 @@ install(PROGRAMS
   scripts/nav2_lifecycle_bringup.py
   scripts/train_residual_model.py
   scripts/pi_mppi_e2e_test.py
+  scripts/controller_benchmark.py
+  scripts/benchmark_report.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2_ws/src/mpc_controller_ros2/scripts/benchmark_report.py
+++ b/ros2_ws/src/mpc_controller_ros2/scripts/benchmark_report.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""
+benchmark_report.py
+===================
+벤치마크 JSON 결과 → ASCII 비교 테이블 + CSV + 선택적 matplotlib 플롯
+
+사용법:
+    # 단일 결과 리포트
+    python3 benchmark_report.py ~/benchmark_results/bench_20260316_120000.json
+
+    # 복수 결과 비교 (서로 다른 world/설정 비교)
+    python3 benchmark_report.py result1.json result2.json
+
+    # CSV만 내보내기
+    python3 benchmark_report.py result.json --csv-only
+
+    # matplotlib 플롯 생성
+    python3 benchmark_report.py result.json --plot
+
+    # 특정 메트릭으로 정렬
+    python3 benchmark_report.py result.json --sort-by rms_jerk
+
+    # 랭킹 테이블
+    python3 benchmark_report.py result.json --ranking
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ─── 메트릭 정의 ─────────────────────────────────────────────────
+
+METRIC_DEFS = {
+    # (display_name, unit, format, lower_is_better)
+    'goal_reached':       ('Goal',      '',    '{!s:>5}',  None),
+    'travel_time':        ('Time',      's',   '{:.1f}',   True),
+    'travel_distance':    ('Dist',      'm',   '{:.2f}',   None),  # 상황 의존
+    'position_error':     ('PosErr',    'm',   '{:.3f}',   True),
+    'yaw_error':          ('YawErr',    'rad', '{:.3f}',   True),
+    'mean_speed':         ('MeanSpd',   'm/s', '{:.2f}',   None),
+    'max_speed':          ('MaxSpd',    'm/s', '{:.2f}',   None),
+    'mean_jerk_vx':       ('JerkVx',    'm/s³','{:.2f}',   True),
+    'mean_jerk_vy':       ('JerkVy',    'm/s³','{:.2f}',   True),
+    'mean_jerk_omega':    ('JerkOm',    'r/s³','{:.2f}',   True),
+    'rms_jerk':           ('RMSJerk',   'm/s³','{:.2f}',   True),
+    'stall_ratio':        ('Stall',     '%',   '{:.1%}',   True),
+    'min_obstacle_dist':  ('MinObs',    'm',   '{:.2f}',   False),  # 높을수록 안전
+    'mean_obstacle_dist': ('MeanObs',   'm',   '{:.2f}',   False),
+    'near_misses':        ('NearMiss',  '',    '{:d}',     True),
+    'collisions':         ('Collisions','',    '{:d}',     True),
+}
+
+# 요약 테이블에 표시할 핵심 메트릭
+SUMMARY_METRICS = [
+    'goal_reached', 'travel_time', 'position_error',
+    'rms_jerk', 'min_obstacle_dist', 'collisions', 'mean_speed',
+]
+
+# 상세 테이블 메트릭
+DETAIL_METRICS = list(METRIC_DEFS.keys())
+
+# 카테고리 분류
+METRIC_CATEGORIES = {
+    'Performance': ['travel_time', 'travel_distance', 'mean_speed', 'max_speed'],
+    'Accuracy': ['position_error', 'yaw_error'],
+    'Smoothness': ['mean_jerk_vx', 'mean_jerk_vy', 'mean_jerk_omega', 'rms_jerk'],
+    'Safety': ['min_obstacle_dist', 'mean_obstacle_dist', 'near_misses', 'collisions'],
+    'Efficiency': ['stall_ratio'],
+}
+
+
+def load_results(filepath: str) -> Dict:
+    """JSON 결과 파일 로드"""
+    with open(filepath, 'r') as f:
+        return json.load(f)
+
+
+def get_successful_results(data: Dict) -> List[Dict]:
+    """성공한 결과만 필터링"""
+    results = data.get('results', [])
+    return [r for r in results if r.get('status') == 'SUCCESS' and r.get('metrics')]
+
+
+def format_metric(key: str, value: Any) -> str:
+    """메트릭 값을 형식화된 문자열로 변환"""
+    if value is None or value == '':
+        return '—'
+
+    _, _, fmt, _ = METRIC_DEFS.get(key, ('', '', '{!s}', None))
+
+    try:
+        if key == 'goal_reached':
+            return '✓' if value else '✗'
+        if key == 'min_obstacle_dist' and value == float('inf'):
+            return '∞'
+        return fmt.format(value)
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def compute_rankings(results: List[Dict], metric_keys: List[str]) -> Dict[str, List[Tuple[str, Any]]]:
+    """각 메트릭별 순위 계산"""
+    rankings = {}
+
+    for key in metric_keys:
+        _, _, _, lower_is_better = METRIC_DEFS.get(key, ('', '', '{}', None))
+        if lower_is_better is None:
+            continue
+
+        scored = []
+        for r in results:
+            metrics = r.get('metrics', {})
+            val = metrics.get(key)
+            if val is not None and val != '' and val != float('inf'):
+                scored.append((r['controller'], val))
+
+        if not scored:
+            continue
+
+        scored.sort(key=lambda x: x[1], reverse=not lower_is_better)
+        rankings[key] = scored
+
+    return rankings
+
+
+def print_summary_table(results: List[Dict], sort_by: Optional[str] = None):
+    """요약 비교 테이블 출력"""
+    if not results:
+        print('  No successful results to display.')
+        return
+
+    # 정렬
+    if sort_by and sort_by in METRIC_DEFS:
+        _, _, _, lower_is_better = METRIC_DEFS[sort_by]
+        results = sorted(
+            results,
+            key=lambda r: r.get('metrics', {}).get(sort_by, float('inf')
+                if lower_is_better else float('-inf')),
+            reverse=not (lower_is_better if lower_is_better is not None else True)
+        )
+
+    # 컬럼 폭 계산
+    ctrl_width = max(len(r['controller']) for r in results) + 1
+    ctrl_width = max(ctrl_width, 12)
+
+    # 헤더
+    header_parts = [f'{"Controller":<{ctrl_width}}']
+    for key in SUMMARY_METRICS:
+        display_name, unit, _, _ = METRIC_DEFS[key]
+        col_header = display_name
+        header_parts.append(f'{col_header:>10}')
+    header = ' '.join(header_parts)
+
+    print()
+    print('┌' + '─' * (len(header) + 2) + '┐')
+    print('│ ' + header + ' │')
+    print('├' + '─' * (len(header) + 2) + '┤')
+
+    for r in results:
+        metrics = r.get('metrics', {})
+        parts = [f'{r["controller"]:<{ctrl_width}}']
+        for key in SUMMARY_METRICS:
+            val = metrics.get(key)
+            parts.append(f'{format_metric(key, val):>10}')
+        print('│ ' + ' '.join(parts) + ' │')
+
+    print('└' + '─' * (len(header) + 2) + '┘')
+
+
+def print_category_tables(results: List[Dict]):
+    """카테고리별 상세 테이블 출력"""
+    if not results:
+        return
+
+    ctrl_width = max(len(r['controller']) for r in results) + 1
+    ctrl_width = max(ctrl_width, 12)
+
+    for category, metric_keys in METRIC_CATEGORIES.items():
+        # 데이터가 있는 메트릭만 필터
+        active_keys = []
+        for key in metric_keys:
+            has_data = any(
+                r.get('metrics', {}).get(key) is not None
+                for r in results
+            )
+            if has_data:
+                active_keys.append(key)
+
+        if not active_keys:
+            continue
+
+        print(f'\n  ── {category} ──')
+
+        header_parts = [f'{"Controller":<{ctrl_width}}']
+        for key in active_keys:
+            display_name, unit, _, _ = METRIC_DEFS[key]
+            col = f'{display_name}({unit})' if unit else display_name
+            header_parts.append(f'{col:>12}')
+        header = ' '.join(header_parts)
+        print(f'  {header}')
+        print(f'  {"─" * len(header)}')
+
+        for r in results:
+            metrics = r.get('metrics', {})
+            parts = [f'{r["controller"]:<{ctrl_width}}']
+            for key in active_keys:
+                val = metrics.get(key)
+                parts.append(f'{format_metric(key, val):>12}')
+            print(f'  {" ".join(parts)}')
+
+
+def print_rankings(results: List[Dict]):
+    """메트릭별 순위 출력"""
+    rankings = compute_rankings(results, DETAIL_METRICS)
+
+    if not rankings:
+        return
+
+    print()
+    print('┌' + '─' * 60 + '┐')
+    print('│  RANKINGS (Best → Worst)' + ' ' * 35 + '│')
+    print('├' + '─' * 60 + '┤')
+
+    icons = {
+        'travel_time': '⏱ ',
+        'position_error': '📐',
+        'yaw_error': '🧭',
+        'rms_jerk': '〰️',
+        'mean_jerk_vx': '〰️',
+        'min_obstacle_dist': '🛡 ',
+        'collisions': '💥',
+        'near_misses': '⚠️ ',
+        'stall_ratio': '🐢',
+    }
+
+    for key, ranked in rankings.items():
+        display_name, unit, fmt, _ = METRIC_DEFS[key]
+        icon = icons.get(key, '  ')
+
+        if len(ranked) < 2:
+            continue
+
+        best_ctrl, best_val = ranked[0]
+        worst_ctrl, worst_val = ranked[-1]
+
+        best_str = fmt.format(best_val)
+        worst_str = fmt.format(worst_val)
+
+        line = f'│  {icon} {display_name:<12} Best: {best_ctrl:<20} ({best_str}{unit})'
+        print(f'{line:<61}│')
+
+        if len(ranked) > 2:
+            mid_ctrl, mid_val = ranked[len(ranked) // 2]
+            mid_str = fmt.format(mid_val)
+            mid_line = f'│     {"":12} Mid:  {mid_ctrl:<20} ({mid_str}{unit})'
+            print(f'{mid_line:<61}│')
+
+    print('└' + '─' * 60 + '┘')
+
+
+def print_radar_ascii(results: List[Dict]):
+    """ASCII 레이더 차트 (정규화 바 차트)"""
+    if len(results) < 2:
+        return
+
+    # 정규화할 메트릭
+    radar_metrics = ['travel_time', 'position_error', 'rms_jerk',
+                     'min_obstacle_dist', 'mean_speed']
+
+    print()
+    print('  ── Normalized Comparison (bar = relative score, longer = better) ──')
+
+    for key in radar_metrics:
+        display_name, unit, _, lower_is_better = METRIC_DEFS.get(key, ('', '', '{}', None))
+        if lower_is_better is None:
+            continue
+
+        values = []
+        for r in results:
+            val = r.get('metrics', {}).get(key)
+            if val is not None and val != float('inf') and val != float('-inf'):
+                values.append((r['controller'], float(val)))
+
+        if len(values) < 2:
+            continue
+
+        min_val = min(v for _, v in values)
+        max_val = max(v for _, v in values)
+        val_range = max_val - min_val
+
+        if val_range < 1e-9:
+            continue
+
+        print(f'\n  {display_name} ({unit}):')
+        ctrl_width = max(len(c) for c, _ in values)
+
+        for ctrl, val in values:
+            if lower_is_better:
+                # 낮을수록 좋으므로 반전
+                score = 1.0 - (val - min_val) / val_range
+            else:
+                score = (val - min_val) / val_range
+
+            bar_len = int(score * 30)
+            bar = '█' * bar_len + '░' * (30 - bar_len)
+            print(f'    {ctrl:<{ctrl_width}} {bar} {val:.3f}')
+
+
+def export_csv(results: List[Dict], output_path: str):
+    """결과를 CSV로 내보내기"""
+    with open(output_path, 'w', newline='') as f:
+        writer = csv.writer(f)
+
+        header = ['controller', 'status'] + list(METRIC_DEFS.keys())
+        writer.writerow(header)
+
+        for r in results:
+            row = [r.get('controller', ''), r.get('status', '')]
+            metrics = r.get('metrics') or {}
+            for key in METRIC_DEFS:
+                row.append(metrics.get(key, ''))
+            writer.writerow(row)
+
+    print(f'  CSV exported: {output_path}')
+
+
+def generate_plots(results: List[Dict], output_dir: str):
+    """matplotlib 비교 플롯 생성"""
+    try:
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        print('  [WARN] matplotlib not available. Skipping plots.')
+        return
+
+    os.makedirs(output_dir, exist_ok=True)
+    controllers = [r['controller'] for r in results]
+
+    # 1. 핵심 메트릭 바 차트
+    fig, axes = plt.subplots(2, 3, figsize=(18, 10))
+    fig.suptitle('MPPI Controller Benchmark Comparison', fontsize=14)
+
+    plot_metrics = [
+        ('travel_time', 'Travel Time (s)', True),
+        ('position_error', 'Position Error (m)', True),
+        ('rms_jerk', 'RMS Jerk (m/s³)', True),
+        ('min_obstacle_dist', 'Min Obstacle Dist (m)', False),
+        ('mean_speed', 'Mean Speed (m/s)', False),
+        ('collisions', 'Collisions', True),
+    ]
+
+    for idx, (key, title, lower_better) in enumerate(plot_metrics):
+        ax = axes[idx // 3][idx % 3]
+        values = []
+        labels = []
+
+        for r in results:
+            val = r.get('metrics', {}).get(key)
+            if val is not None and val != float('inf'):
+                values.append(float(val))
+                labels.append(r['controller'])
+
+        if not values:
+            ax.set_title(f'{title}\n(no data)')
+            continue
+
+        colors = ['#2ecc71' if lower_better == (v == min(values))
+                  or (not lower_better and v == max(values))
+                  else '#3498db' for v in values]
+
+        bars = ax.barh(range(len(values)), values, color=colors)
+        ax.set_yticks(range(len(values)))
+        ax.set_yticklabels(labels, fontsize=8)
+        ax.set_title(title, fontsize=10)
+        ax.invert_yaxis()
+
+        # 값 라벨
+        for bar, val in zip(bars, values):
+            ax.text(bar.get_width(), bar.get_y() + bar.get_height() / 2,
+                    f' {val:.2f}', va='center', fontsize=7)
+
+    plt.tight_layout()
+    plot_path = os.path.join(output_dir, 'benchmark_comparison.png')
+    plt.savefig(plot_path, dpi=150, bbox_inches='tight')
+    plt.close()
+    print(f'  Plot saved: {plot_path}')
+
+    # 2. 레이더 차트 (상위 6개)
+    if len(results) >= 3:
+        radar_keys = ['travel_time', 'position_error', 'rms_jerk',
+                      'min_obstacle_dist', 'mean_speed']
+        radar_labels = ['Time↓', 'PosErr↓', 'Jerk↓', 'MinObs↑', 'Speed↑']
+        lower_better_flags = [True, True, True, False, False]
+
+        # 정규화
+        all_vals = {k: [] for k in radar_keys}
+        for r in results:
+            for k in radar_keys:
+                v = r.get('metrics', {}).get(k)
+                if v is not None and v != float('inf'):
+                    all_vals[k].append(float(v))
+
+        fig, ax = plt.subplots(figsize=(8, 8), subplot_kw=dict(polar=True))
+        angles = np.linspace(0, 2 * np.pi, len(radar_keys), endpoint=False).tolist()
+        angles += angles[:1]
+
+        for r in results[:6]:  # 상위 6개만
+            scores = []
+            for k, lb in zip(radar_keys, lower_better_flags):
+                v = r.get('metrics', {}).get(k)
+                vals = all_vals[k]
+                if v is None or not vals or v == float('inf'):
+                    scores.append(0.5)
+                    continue
+                mn, mx = min(vals), max(vals)
+                rng = mx - mn
+                if rng < 1e-9:
+                    scores.append(0.5)
+                else:
+                    norm = (float(v) - mn) / rng
+                    scores.append(1.0 - norm if lb else norm)
+
+            scores += scores[:1]
+            ax.plot(angles, scores, 'o-', label=r['controller'], linewidth=1.5)
+            ax.fill(angles, scores, alpha=0.1)
+
+        ax.set_xticks(angles[:-1])
+        ax.set_xticklabels(radar_labels, fontsize=9)
+        ax.set_ylim(0, 1)
+        ax.set_title('Controller Radar Comparison\n(outer = better)', fontsize=12)
+        ax.legend(loc='upper right', bbox_to_anchor=(1.3, 1.0), fontsize=8)
+
+        radar_path = os.path.join(output_dir, 'benchmark_radar.png')
+        plt.savefig(radar_path, dpi=150, bbox_inches='tight')
+        plt.close()
+        print(f'  Radar plot saved: {radar_path}')
+
+
+def generate_report_from_files(filepaths: List[str], sort_by: Optional[str] = None,
+                               csv_only: bool = False, plot: bool = False,
+                               ranking: bool = False):
+    """파일 목록에서 리포트 생성 (controller_benchmark.py --report-only에서 호출)"""
+    all_results = []
+
+    for fp in filepaths:
+        data = load_results(fp)
+        successful = get_successful_results(data)
+        all_results.extend(successful)
+
+        suite_name = data.get('suite_name', os.path.basename(fp))
+        print(f'\n  Loaded: {fp} ({len(successful)} successful results)')
+
+    if not all_results:
+        print('  No successful results found in any file.')
+        return
+
+    if csv_only:
+        csv_path = filepaths[0].replace('.json', '_report.csv')
+        export_csv(all_results, csv_path)
+        return
+
+    # 요약 테이블
+    print_summary_table(all_results, sort_by=sort_by)
+
+    # 카테고리별 상세
+    print_category_tables(all_results)
+
+    # 순위
+    if ranking or len(all_results) >= 3:
+        print_rankings(all_results)
+
+    # ASCII 비교
+    if len(all_results) >= 2:
+        print_radar_ascii(all_results)
+
+    # 플롯
+    if plot:
+        output_dir = os.path.dirname(filepaths[0]) or '.'
+        generate_plots(all_results, output_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='벤치마크 결과 리포트 생성기',
+    )
+
+    parser.add_argument('files', nargs='+', help='벤치마크 JSON 결과 파일')
+    parser.add_argument('--sort-by', type=str, default=None,
+                        choices=list(METRIC_DEFS.keys()),
+                        help='정렬 기준 메트릭')
+    parser.add_argument('--csv-only', action='store_true',
+                        help='CSV만 내보내기')
+    parser.add_argument('--csv-output', type=str, default=None,
+                        help='CSV 출력 경로 (기본: 입력파일명_report.csv)')
+    parser.add_argument('--plot', action='store_true',
+                        help='matplotlib 플롯 생성')
+    parser.add_argument('--ranking', action='store_true',
+                        help='순위 테이블 표시')
+    parser.add_argument('--detail', action='store_true',
+                        help='카테고리별 상세 테이블')
+
+    args = parser.parse_args()
+
+    all_results = []
+    for fp in args.files:
+        if not os.path.exists(fp):
+            print(f'  [ERROR] File not found: {fp}')
+            continue
+
+        data = load_results(fp)
+        successful = get_successful_results(data)
+        all_results.extend(successful)
+        print(f'  Loaded: {fp} ({len(successful)} successful)')
+
+    if not all_results:
+        print('  No successful results found.')
+        sys.exit(1)
+
+    if args.csv_only:
+        csv_path = args.csv_output or args.files[0].replace('.json', '_report.csv')
+        export_csv(all_results, csv_path)
+        return
+
+    # 요약
+    print_summary_table(all_results, sort_by=args.sort_by)
+
+    # 상세
+    if args.detail:
+        print_category_tables(all_results)
+
+    # 순위
+    if args.ranking or len(all_results) >= 3:
+        print_rankings(all_results)
+
+    # ASCII 비교
+    if len(all_results) >= 2:
+        print_radar_ascii(all_results)
+
+    # 플롯
+    if args.plot:
+        output_dir = os.path.dirname(args.files[0]) or '.'
+        generate_plots(all_results, output_dir)
+
+    # CSV도 항상 내보내기
+    csv_path = args.csv_output or args.files[0].replace('.json', '_report.csv')
+    export_csv(all_results, csv_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_ws/src/mpc_controller_ros2/scripts/controller_benchmark.py
+++ b/ros2_ws/src/mpc_controller_ros2/scripts/controller_benchmark.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""
+controller_benchmark.py
+=======================
+20종 MPPI 컨트롤러 자동 벤치마크 오케스트레이터
+
+diff_drive / swerve / ackermann 모든 모션 모델을 지원하며,
+각 컨트롤러별로 launch → E2E 테스트 → 메트릭 수집을 순차 실행합니다.
+
+사용법:
+    # diff_drive 컨트롤러 전체 벤치마크
+    python3 controller_benchmark.py --group diff_drive
+
+    # swerve 컨트롤러 전체 벤치마크
+    python3 controller_benchmark.py --group swerve
+
+    # 특정 컨트롤러만 벤치마크
+    python3 controller_benchmark.py --controllers custom log shield
+
+    # 커스텀 goal + world
+    python3 controller_benchmark.py --group swerve \
+        --world narrow_passage_world.world --map narrow_passage_map.yaml \
+        --goal-x 5.0 --goal-y -3.5
+
+    # 이전 결과에서 리포트만 생성
+    python3 controller_benchmark.py --report-only ~/benchmark_results/bench_20260316_*.json
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# ─── 컨트롤러 그룹 정의 ─────────────────────────────────────────────
+
+DIFF_DRIVE_CONTROLLERS = [
+    'custom', 'log', 'tsallis', 'risk_aware', 'svmpc',
+    'smooth', 'spline', 'svg', 'biased', 'dial',
+    'shield', 'adaptive_shield', 'clf_cbf', 'predictive_safety',
+    'ilqr_mppi', 'cs_mppi', 'pi_mppi',
+]
+
+SWERVE_CONTROLLERS = [
+    'swerve', 'log_swerve', 'tsallis_swerve', 'smooth_swerve',
+    'biased_swerve', 'shield_swerve', 'cs_swerve', 'pi_swerve',
+    'svg_swerve', 'ilqr_swerve', 'dial_swerve',
+    'hybrid_swerve', 'non_coaxial',
+]
+
+ACKERMANN_CONTROLLERS = [
+    'ackermann',
+]
+
+ALL_CONTROLLERS = DIFF_DRIVE_CONTROLLERS + SWERVE_CONTROLLERS + ACKERMANN_CONTROLLERS
+
+GROUP_MAP = {
+    'diff_drive': DIFF_DRIVE_CONTROLLERS,
+    'swerve': SWERVE_CONTROLLERS,
+    'ackermann': ACKERMANN_CONTROLLERS,
+    'all': ALL_CONTROLLERS,
+    'safety': ['shield', 'adaptive_shield', 'clf_cbf', 'predictive_safety', 'shield_swerve'],
+    'quick': ['custom', 'log', 'smooth', 'shield'],
+}
+
+# ─── 기본 설정 ────────────────────────────────────────────────────
+
+DEFAULT_WORLD = 'maze_world.world'
+DEFAULT_MAP = 'maze_map.yaml'
+DEFAULT_GOAL_X = 3.0
+DEFAULT_GOAL_Y = 0.0
+DEFAULT_GOAL_YAW = 0.0
+DEFAULT_TIMEOUT = 90
+LAUNCH_STABILIZE_SEC = 35
+NAV2_ACTIVATE_SEC = 30
+NAV2_CHECK_RETRIES = 10
+NAV2_CHECK_INTERVAL = 5
+
+
+@dataclass
+class BenchmarkResult:
+    """단일 컨트롤러 벤치마크 결과"""
+    controller: str
+    status: str  # 'SUCCESS', 'LAUNCH_FAILED', 'NAV2_TIMEOUT', 'TEST_FAILED'
+    metrics: Optional[Dict] = None
+    error_message: str = ''
+    duration_sec: float = 0.0
+    timestamp: str = ''
+
+
+@dataclass
+class BenchmarkSuite:
+    """벤치마크 스위트 전체 결과"""
+    suite_name: str
+    world: str
+    map_name: str
+    goal: Dict
+    start_time: str
+    end_time: str = ''
+    results: List[Dict] = field(default_factory=list)
+    total_controllers: int = 0
+    successful: int = 0
+    failed: int = 0
+
+
+def cleanup_processes():
+    """이전 launch 프로세스 정리"""
+    cleanup_script = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        'cleanup_launch.sh'
+    )
+    if os.path.exists(cleanup_script):
+        subprocess.run(['bash', cleanup_script], capture_output=True, timeout=15)
+    else:
+        # 직접 정리
+        patterns = [
+            'gz sim', 'parameter_bridge', 'twist_stamper',
+            'swerve_kinematics_node', 'odom_to_tf',
+            'nav2_lifecycle_bringup', 'robot_state_publisher',
+            'map_server --ros', 'amcl --ros',
+            'controller_server --ros', 'planner_server --ros',
+            'behavior_server --ros', 'bt_navigator --ros',
+            'rviz2',
+        ]
+        for pat in patterns:
+            subprocess.run(
+                ['pkill', '-9', '-f', pat],
+                capture_output=True
+            )
+    time.sleep(3)
+
+
+def wait_for_nav2_active(timeout_sec: int = NAV2_ACTIVATE_SEC,
+                         retries: int = NAV2_CHECK_RETRIES) -> bool:
+    """nav2 lifecycle 활성화 대기"""
+    time.sleep(timeout_sec)
+
+    for i in range(retries):
+        try:
+            bt_result = subprocess.run(
+                ['ros2', 'lifecycle', 'get', '/bt_navigator'],
+                capture_output=True, text=True, timeout=10
+            )
+            ctrl_result = subprocess.run(
+                ['ros2', 'lifecycle', 'get', '/controller_server'],
+                capture_output=True, text=True, timeout=10
+            )
+            bt_active = 'active' in bt_result.stdout.lower()
+            ctrl_active = 'active' in ctrl_result.stdout.lower()
+
+            if bt_active and ctrl_active:
+                return True
+        except (subprocess.TimeoutExpired, Exception):
+            pass
+
+        time.sleep(NAV2_CHECK_INTERVAL)
+
+    return False
+
+
+def run_e2e_test(goal_x: float, goal_y: float, goal_yaw: float,
+                 timeout: float) -> Optional[Dict]:
+    """E2E 테스트 실행 및 결과 파싱"""
+    cmd = [
+        'ros2', 'run', 'mpc_controller_ros2', 'swerve_e2e_test.py',
+        '--x', str(goal_x),
+        '--y', str(goal_y),
+        '--yaw', str(goal_yaw),
+        '--timeout', str(timeout),
+        '--no-save',
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True, text=True,
+            timeout=int(timeout) + 30
+        )
+        output = result.stdout + result.stderr
+
+        # 메트릭 파싱
+        metrics = parse_e2e_output(output)
+        return metrics
+
+    except subprocess.TimeoutExpired:
+        return None
+    except Exception as e:
+        print(f'  [ERROR] E2E test exception: {e}')
+        return None
+
+
+def parse_e2e_output(output: str) -> Dict:
+    """E2E 테스트 출력에서 메트릭 추출"""
+    metrics = {}
+    lines = output.split('\n')
+
+    parse_map = {
+        'Goal reached': ('goal_reached', lambda v: v.strip().upper() == 'YES'),
+        'Travel time': ('travel_time', lambda v: float(v.split()[0])),
+        'Travel distance': ('travel_distance', lambda v: float(v.split()[0])),
+        'Position error': ('position_error', lambda v: float(v.split()[0])),
+        'Yaw error': ('yaw_error', lambda v: float(v.split()[0])),
+        'Mean speed': ('mean_speed', lambda v: float(v.split()[0])),
+        'Max speed': ('max_speed', lambda v: float(v.split()[0])),
+        'Mean jerk vx': ('mean_jerk_vx', lambda v: float(v.split()[0])),
+        'Mean jerk vy': ('mean_jerk_vy', lambda v: float(v.split()[0])),
+        'Mean jerk omega': ('mean_jerk_omega', lambda v: float(v.split()[0])),
+        'RMS jerk': ('rms_jerk', lambda v: float(v.split()[0])),
+        'Stall ratio': ('stall_ratio', lambda v: float(v.strip().rstrip('%')) / 100.0),
+        'Stall samples': ('stall_samples', lambda v: int(v.split('/')[0].strip())),
+        'Min distance': ('min_obstacle_dist', lambda v: float(v.split()[0])),
+        'Mean min dist': ('mean_obstacle_dist', lambda v: float(v.split()[0])),
+        'Near misses': ('near_misses', lambda v: int(v.split()[0])),
+        'Collisions': ('collisions', lambda v: int(v.split()[0])),
+    }
+
+    for line in lines:
+        for key, (metric_name, parser) in parse_map.items():
+            if key in line and ':' in line:
+                try:
+                    value_str = line.split(':', 1)[1].strip()
+                    metrics[metric_name] = parser(value_str)
+                except (ValueError, IndexError):
+                    pass
+
+    return metrics
+
+
+def run_single_benchmark(controller: str, args, idx: int, total: int) -> BenchmarkResult:
+    """단일 컨트롤러 벤치마크 실행"""
+    result = BenchmarkResult(
+        controller=controller,
+        status='UNKNOWN',
+        timestamp=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+    )
+
+    start = time.time()
+
+    print()
+    print('━' * 64)
+    print(f'  [{idx}/{total}] {controller}')
+    print('━' * 64)
+
+    # 1. 정리
+    print('  [1/5] Cleaning up previous processes...')
+    cleanup_processes()
+
+    # 2. Launch 시작
+    print(f'  [2/5] Launching controller={controller} ...')
+    launch_cmd = [
+        'ros2', 'launch', 'mpc_controller_ros2', 'mppi_ros2_control_nav2.launch.py',
+        f'controller:={controller}',
+        f'world:={args.world}',
+        f'map:={args.map}',
+        'headless:=true',
+    ]
+
+    launch_log = f'/tmp/bench_launch_{controller}.log'
+    with open(launch_log, 'w') as log_f:
+        launch_proc = subprocess.Popen(
+            launch_cmd,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            preexec_fn=os.setsid,
+        )
+
+    print(f'  [2/5] PID={launch_proc.pid}, stabilizing ({LAUNCH_STABILIZE_SEC}s)...')
+    time.sleep(LAUNCH_STABILIZE_SEC)
+
+    # launch 생존 확인
+    if launch_proc.poll() is not None:
+        result.status = 'LAUNCH_FAILED'
+        result.error_message = f'Launch crashed (exit code {launch_proc.returncode})'
+        result.duration_sec = time.time() - start
+        print(f'  [ERROR] {result.error_message}')
+        cleanup_processes()
+        return result
+
+    # 3. nav2 활성화 대기
+    print(f'  [3/5] Waiting for nav2 activation...')
+    if not wait_for_nav2_active():
+        result.status = 'NAV2_TIMEOUT'
+        result.error_message = 'nav2 nodes did not reach active state'
+        result.duration_sec = time.time() - start
+        print(f'  [ERROR] {result.error_message}')
+        try:
+            os.killpg(os.getpgid(launch_proc.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        time.sleep(3)
+        cleanup_processes()
+        return result
+
+    print('  [3/5] nav2 active ✓')
+    # 추가 안정화
+    time.sleep(10)
+
+    # 4. E2E 테스트
+    print(f'  [4/5] Running E2E test (goal: {args.goal_x}, {args.goal_y})...')
+    metrics = run_e2e_test(args.goal_x, args.goal_y, args.goal_yaw, args.timeout)
+
+    if metrics:
+        result.status = 'SUCCESS'
+        result.metrics = metrics
+        goal_ok = metrics.get('goal_reached', False)
+        print(f'  [4/5] Test complete (goal_reached={goal_ok})')
+    else:
+        result.status = 'TEST_FAILED'
+        result.error_message = 'E2E test returned no metrics'
+        print(f'  [ERROR] {result.error_message}')
+
+    # 5. 정리
+    print('  [5/5] Shutting down...')
+    try:
+        os.killpg(os.getpgid(launch_proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    time.sleep(3)
+    cleanup_processes()
+
+    result.duration_sec = time.time() - start
+    print(f'  [{controller}] Done ({result.duration_sec:.0f}s) → {result.status}')
+
+    return result
+
+
+def print_summary_table(results: List[BenchmarkResult]):
+    """벤치마크 결과 요약 테이블 출력"""
+    print()
+    print('=' * 100)
+    print('  BENCHMARK SUMMARY')
+    print('=' * 100)
+
+    # 헤더
+    header = (
+        f'{"Controller":<22} {"Status":<12} '
+        f'{"Goal":>4} {"Time":>7} {"Dist":>7} '
+        f'{"PosErr":>7} {"Jerk":>8} '
+        f'{"MinObs":>7} {"Coll":>4} '
+        f'{"Speed":>6}'
+    )
+    print(header)
+    print('-' * 100)
+
+    success_results = []
+
+    for r in results:
+        if r.status == 'SUCCESS' and r.metrics:
+            m = r.metrics
+            goal = '✓' if m.get('goal_reached', False) else '✗'
+            line = (
+                f'{r.controller:<22} {"OK":<12} '
+                f'{goal:>4} '
+                f'{m.get("travel_time", 0):.1f}s'.rjust(7) + ' '
+                f'{m.get("travel_distance", 0):.2f}m'.rjust(7) + ' '
+                f'{m.get("position_error", 0):.3f}'.rjust(7) + ' '
+                f'{m.get("rms_jerk", 0):.2f}'.rjust(8) + ' '
+                f'{m.get("min_obstacle_dist", float("inf")):.2f}'.rjust(7) + ' '
+                f'{m.get("collisions", 0)}'.rjust(4) + ' '
+                f'{m.get("mean_speed", 0):.2f}'.rjust(6)
+            )
+            print(line)
+            success_results.append(r)
+        else:
+            print(f'{r.controller:<22} {r.status:<12} {"—":>4} {"—":>7} {"—":>7} '
+                  f'{"—":>7} {"—":>8} {"—":>7} {"—":>4} {"—":>6}')
+
+    print('-' * 100)
+
+    # 순위 (성공한 결과만)
+    if len(success_results) >= 2:
+        print()
+        print('  RANKINGS (성공한 컨트롤러만)')
+        print('-' * 60)
+
+        # 최단 시간
+        by_time = sorted(
+            [r for r in success_results if r.metrics.get('goal_reached')],
+            key=lambda r: r.metrics.get('travel_time', float('inf'))
+        )
+        if by_time:
+            print(f'  ⏱  Fastest:     {by_time[0].controller} '
+                  f'({by_time[0].metrics["travel_time"]:.1f}s)')
+
+        # 최소 jerk
+        by_jerk = sorted(
+            success_results,
+            key=lambda r: r.metrics.get('rms_jerk', float('inf'))
+        )
+        print(f'  🎯 Smoothest:   {by_jerk[0].controller} '
+              f'(jerk={by_jerk[0].metrics.get("rms_jerk", 0):.2f})')
+
+        # 최소 위치 오차
+        by_err = sorted(
+            [r for r in success_results if r.metrics.get('goal_reached')],
+            key=lambda r: r.metrics.get('position_error', float('inf'))
+        )
+        if by_err:
+            print(f'  📐 Most accurate: {by_err[0].controller} '
+                  f'(err={by_err[0].metrics.get("position_error", 0):.3f}m)')
+
+        # 안전성 (최대 min_obstacle_dist)
+        by_safety = sorted(
+            success_results,
+            key=lambda r: r.metrics.get('min_obstacle_dist', 0),
+            reverse=True
+        )
+        dist = by_safety[0].metrics.get('min_obstacle_dist', 0)
+        if dist < float('inf'):
+            print(f'  🛡  Safest:      {by_safety[0].controller} '
+                  f'(min_obs={dist:.2f}m)')
+
+    # 통계
+    total = len(results)
+    ok = sum(1 for r in results if r.status == 'SUCCESS')
+    goals = sum(1 for r in success_results
+                if r.metrics and r.metrics.get('goal_reached'))
+    print()
+    print(f'  Total: {total} | Success: {ok} | Goals reached: {goals} | '
+          f'Failed: {total - ok}')
+    print('=' * 100)
+
+
+def save_results(suite: BenchmarkSuite, output_dir: str) -> str:
+    """결과를 JSON + CSV로 저장"""
+    os.makedirs(output_dir, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+
+    # JSON
+    json_path = os.path.join(output_dir, f'bench_{timestamp}.json')
+    with open(json_path, 'w') as f:
+        json.dump(asdict(suite), f, indent=2, default=str)
+
+    # CSV
+    csv_path = os.path.join(output_dir, f'bench_{timestamp}.csv')
+    metric_keys = [
+        'goal_reached', 'travel_time', 'travel_distance',
+        'position_error', 'yaw_error', 'mean_speed', 'max_speed',
+        'mean_jerk_vx', 'mean_jerk_vy', 'mean_jerk_omega', 'rms_jerk',
+        'stall_ratio', 'min_obstacle_dist', 'mean_obstacle_dist',
+        'near_misses', 'collisions',
+    ]
+
+    with open(csv_path, 'w') as f:
+        header = 'controller,status,' + ','.join(metric_keys)
+        f.write(header + '\n')
+
+        for r in suite.results:
+            row = [r.get('controller', ''), r.get('status', '')]
+            metrics = r.get('metrics') or {}
+            for k in metric_keys:
+                val = metrics.get(k, '')
+                row.append(str(val))
+            f.write(','.join(row) + '\n')
+
+    print(f'\n  Results saved:')
+    print(f'    JSON: {json_path}')
+    print(f'    CSV:  {csv_path}')
+
+    return json_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='MPPI 컨트롤러 자동 벤치마크 대시보드',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+컨트롤러 그룹:
+  diff_drive  17종 (custom, log, tsallis, ...)
+  swerve      13종 (swerve, log_swerve, ...)
+  ackermann    1종 (ackermann)
+  safety       5종 (shield, adaptive_shield, clf_cbf, predictive_safety, shield_swerve)
+  quick        4종 (custom, log, smooth, shield)
+  all         31종 (전체)
+''')
+
+    parser.add_argument('--group', type=str, default=None,
+                        choices=list(GROUP_MAP.keys()),
+                        help='컨트롤러 그룹 (기본: quick)')
+    parser.add_argument('--controllers', nargs='+', default=None,
+                        help='특정 컨트롤러 목록')
+    parser.add_argument('--world', type=str, default=DEFAULT_WORLD,
+                        help=f'Gazebo world 파일 (기본: {DEFAULT_WORLD})')
+    parser.add_argument('--map', type=str, default=DEFAULT_MAP,
+                        help=f'nav2 맵 파일 (기본: {DEFAULT_MAP})')
+    parser.add_argument('--goal-x', type=float, default=DEFAULT_GOAL_X,
+                        dest='goal_x', help='목표 x (m)')
+    parser.add_argument('--goal-y', type=float, default=DEFAULT_GOAL_Y,
+                        dest='goal_y', help='목표 y (m)')
+    parser.add_argument('--goal-yaw', type=float, default=DEFAULT_GOAL_YAW,
+                        dest='goal_yaw', help='목표 yaw (rad)')
+    parser.add_argument('--timeout', type=float, default=DEFAULT_TIMEOUT,
+                        help=f'E2E 테스트 타임아웃 (s, 기본: {DEFAULT_TIMEOUT})')
+    parser.add_argument('--output-dir', type=str,
+                        default=os.path.expanduser('~/benchmark_results'),
+                        help='결과 저장 디렉토리')
+    parser.add_argument('--report-only', nargs='+', default=None,
+                        help='기존 JSON 파일에서 리포트만 생성')
+
+    args = parser.parse_args()
+
+    # 리포트 전용 모드
+    if args.report_only:
+        from benchmark_report import generate_report_from_files
+        generate_report_from_files(args.report_only)
+        return
+
+    # 컨트롤러 목록 결정
+    if args.controllers:
+        controllers = args.controllers
+    elif args.group:
+        controllers = GROUP_MAP[args.group]
+    else:
+        controllers = GROUP_MAP['quick']
+
+    # ROS2 환경 확인
+    ros_distro = os.environ.get('ROS_DISTRO', '')
+    if not ros_distro:
+        print('[ERROR] ROS2 환경이 설정되지 않았습니다.')
+        print('  source /opt/ros/jazzy/setup.bash')
+        print('  source ~/toy_claude_project/ros2_ws/install/setup.bash')
+        sys.exit(1)
+
+    # 벤치마크 시작
+    suite = BenchmarkSuite(
+        suite_name=f'MPPI Benchmark ({len(controllers)} controllers)',
+        world=args.world,
+        map_name=args.map,
+        goal={'x': args.goal_x, 'y': args.goal_y, 'yaw': args.goal_yaw},
+        start_time=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        total_controllers=len(controllers),
+    )
+
+    print()
+    print('╔' + '═' * 62 + '╗')
+    print('║  MPPI Controller Benchmark Dashboard' + ' ' * 24 + '║')
+    print('╠' + '═' * 62 + '╣')
+    print(f'║  Controllers: {len(controllers):<47}║')
+    print(f'║  World:       {args.world:<47}║')
+    print(f'║  Map:         {args.map:<47}║')
+    print(f'║  Goal:        ({args.goal_x}, {args.goal_y}, yaw={args.goal_yaw})'
+          .ljust(63) + '║')
+    print(f'║  Timeout:     {args.timeout}s'
+          .ljust(63) + '║')
+    print('╚' + '═' * 62 + '╝')
+    print()
+    print(f'  Controllers: {", ".join(controllers)}')
+    print()
+
+    results = []
+    for idx, ctrl in enumerate(controllers, 1):
+        try:
+            result = run_single_benchmark(ctrl, args, idx, len(controllers))
+            results.append(result)
+        except KeyboardInterrupt:
+            print('\n\n  [INTERRUPTED] Cleaning up...')
+            cleanup_processes()
+            break
+        except Exception as e:
+            print(f'\n  [ERROR] Unexpected error for {ctrl}: {e}')
+            results.append(BenchmarkResult(
+                controller=ctrl,
+                status='ERROR',
+                error_message=str(e),
+                timestamp=datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            ))
+            cleanup_processes()
+
+    suite.end_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    suite.results = [asdict(r) for r in results]
+    suite.successful = sum(1 for r in results if r.status == 'SUCCESS')
+    suite.failed = len(results) - suite.successful
+
+    # 요약 출력
+    print_summary_table(results)
+
+    # 저장
+    save_results(suite, args.output_dir)
+
+    print()
+    print('  Benchmark complete!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- `controller_benchmark.py`: 20종 MPPI 플러그인 자동 벤치마크 오케스트레이터 (launch→E2E→메트릭 순차 실행)
- `benchmark_report.py`: 결과 JSON → ASCII 비교 테이블 + 순위 + 정규화 바차트 + matplotlib 플롯 + CSV

## 기능 요약
```
┌─────────────────────────────────────────────────────┐
│  controller_benchmark.py                            │
│  ├─ 그룹 프리셋: quick(4), diff_drive(17),          │
│  │   swerve(13), safety(5), all(31)                 │
│  ├─ 자동: launch → nav2 활성화 → E2E → 정리        │
│  └─ 출력: JSON + CSV + ASCII 요약                   │
│                                                     │
│  benchmark_report.py                                │
│  ├─ 요약 테이블 (7 핵심 메트릭)                     │
│  ├─ 카테고리별 상세 (Performance/Accuracy/           │
│  │   Smoothness/Safety/Efficiency)                  │
│  ├─ 순위 테이블 (Best/Mid/Worst)                    │
│  ├─ ASCII 정규화 바 차트                            │
│  └─ matplotlib 플롯 (비교 바차트 + 레이더)          │
└─────────────────────────────────────────────────────┘
```

## 사용법
```bash
# Quick 벤치마크 (4종)
python3 controller_benchmark.py --group quick

# 전체 diff_drive 벤치마크
python3 controller_benchmark.py --group diff_drive

# 결과 리포트
python3 benchmark_report.py ~/benchmark_results/bench_*.json --ranking --plot
```

## Test plan
- [x] mock 데이터로 리포트 생성 검증 (요약/상세/순위/플롯)
- [x] colcon build 성공
- [x] gtest 27 스위트 PASS (기존 테스트 회귀 없음)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)